### PR TITLE
Introduce inactive state for partition devices

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -486,13 +486,16 @@ func isValidFileSystem(fs *diskv1.FilesystemInfo, fsStatus *diskv1.FilesystemSta
 }
 
 // SaveBlockDevice persists the blockedevice information. If oldBds contains a
-// blockedevice under the same name, it will only do an update, otherwise create
-// a new one.
+// blockedevice under the same name (GUID), it will only do an update, otherwise
+// create a new one.
+//
+// Note that this method also activate the device if it's previously inactive.
 func (c *Controller) SaveBlockDevice(bd *diskv1.BlockDevice, oldBds map[string]*diskv1.BlockDevice) (*diskv1.BlockDevice, error) {
 	if oldBd, ok := oldBds[bd.Name]; ok {
 		if !reflect.DeepEqual(oldBd.Status.DeviceStatus, bd.Status.DeviceStatus) {
 			logrus.Infof("Update existing block device status %s with devPath: %s", oldBd.Name, oldBd.Spec.DevPath)
 			toUpdate := oldBd.DeepCopy()
+			toUpdate.Status.State = diskv1.BlockDeviceActive
 			toUpdate.Status.DeviceStatus = bd.Status.DeviceStatus
 			lastFormatted := oldBd.Status.DeviceStatus.FileSystem.LastFormattedAt
 			if lastFormatted != nil {


### PR DESCRIPTION
# Introduce inactive state for partition devices

## Background

When we adding a new partition, more than one uevents of that partition are generated, which in the sequence: add, remove, add. This behaviour makes it difficult to blindly delete the blockdevice CR when receiving an uevent with remove action. 

## Proposal

We propose not to remove any parition. We only flag partitions inactive when receiving uevent with remove action against them. The actual removal of a partition device only happens when we tried to remove the whole disk.

## Test plan

At this moment we need to manually test it.

1. Create a k8s cluster with longhorn installed.
2. Run the binary. e.g.`go run main.go`. Don't forget to specify `--namespace` and `--node-name`.
3. Watch the changes of all blockdevice CR. 
3. Plug a raw disk (without any partition) on the machine
    - Expect to see two blockdevices if you cannot generate a valid GUID from the disk: one with deviceType Disk; the other with deviceType Part
    - Expect to see one blockdevice with disk type if your disk has WWN or S/N or GPT partition table inside.
4. Edit the partition blockdevice's `Spec.FileSystem.MountPoint` to a valid path. and also set `Spec.FileSystem.ForceFormatted` to true. ⚠️ This would format the disk
5. You are expected to see that the state of the partition device transit from active to inactive and then back to active. 