### PR TITLE
Switch image repo to rancher/harvester-node-disk-manager

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,7 +42,7 @@ steps:
     dockerfile: package/Dockerfile
     password:
       from_secret: docker_password
-    repo: "longhorn/node-disk-manager"
+    repo: "rancher/harvester-node-disk-manager"
     tag: "${DRONE_TAG}-amd64"
     username:
       from_secret: docker_username
@@ -104,7 +104,7 @@ steps:
     dockerfile: package/Dockerfile
     password:
       from_secret: docker_password
-    repo: "longhorn/node-disk-manager"
+    repo: "rancher/harvester-node-disk-manager"
     tag: "${DRONE_TAG}-arm64"
     username:
       from_secret: docker_username
@@ -166,7 +166,7 @@ steps:
     dockerfile: package/Dockerfile
     password:
       from_secret: docker_password
-    repo: "longhorn/node-disk-manager"
+    repo: "rancher/harvester-node-disk-manager"
     tag: "${DRONE_TAG}-arm"
     username:
       from_secret: docker_username
@@ -204,8 +204,8 @@ steps:
       - linux/amd64
       - linux/arm64
       - linux/arm
-    target: "longhorn/node-disk-manager:${DRONE_TAG}"
-    template: "longhorn/node-disk-manager:${DRONE_TAG}-ARCH"
+    target: "rancher/harvester-node-disk-manager:${DRONE_TAG}"
+    template: "rancher/harvester-node-disk-manager:${DRONE_TAG}-ARCH"
   when:
     instance:
     - drone-publish.rancher.io

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,6 +36,27 @@ steps:
     event:
     - tag
 
+- name: docker-publish-master
+  image: plugins/docker
+  settings:
+    build_args:
+      - ARCH=amd64
+      - VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head
+    dockerfile: package/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/harvester-node-disk-manager"
+    tag: ${DRONE_BRANCH}-head
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/heads/release/v*
+    event:
+    - push
+
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -43,7 +64,7 @@ steps:
     password:
       from_secret: docker_password
     repo: "rancher/harvester-node-disk-manager"
-    tag: "${DRONE_TAG}-amd64"
+    tag: "${DRONE_TAG}"
     username:
       from_secret: docker_username
   when:
@@ -59,163 +80,3 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
----
-kind: pipeline
-name: arm64
-
-platform:
-  os: linux
-  arch: arm64
-
-steps:
-- name: build
-  image: rancher/dapper:v0.4.1
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-arm64.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/harvester-node-disk-manager"
-    tag: "${DRONE_TAG}-arm64"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
-name: arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-- name: build
-  image: rancher/dapper:v0.4.1
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-arm.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/harvester-node-disk-manager"
-    tag: "${DRONE_TAG}-arm"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
-name: manifest
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: manifest
-  image: plugins/manifest:1.0.2
-  settings:
-    username:
-      from_secret: docker_username
-    password:
-      from_secret: docker_password
-    platforms:
-      - linux/amd64
-      - linux/arm64
-      - linux/arm
-    target: "rancher/harvester-node-disk-manager:${DRONE_TAG}"
-    template: "rancher/harvester-node-disk-manager:${DRONE_TAG}-ARCH"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-depends_on:
-- amd64
-- arm64
-- arm


### PR DESCRIPTION
As title, we publish the docker image under repo `rancher/harvester-node-disk-manager` at this moment and remove arm support temporarily.