### PR TITLE
Periodic rescanning for blockdevices

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func main() {
 		},
 		&cli.Int64Flag{
 			Name:        "rescan-interval",
+			EnvVars:     []string{"NDM_RESCAN_INTERVAL"},
 			Usage:       "Specify the interval of device rescanning of the node (in seconds)",
 			Destination: &opt.RescanInterval,
 		},

--- a/main.go
+++ b/main.go
@@ -109,6 +109,12 @@ func main() {
 			Usage:       "Specify the interval of device rescanning of the node (in seconds)",
 			Destination: &opt.RescanInterval,
 		},
+		&cli.BoolFlag{
+			Name:        "auto-gpt-generate",
+			EnvVars:     []string{"NDM_AUTO_GPT_GENERATE"},
+			Usage:       "Enable auto GPT partition generating if a disk can not be globally identified",
+			Destination: &opt.AutoGPTGenerate,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -103,6 +103,11 @@ func main() {
 			Usage:       "A string of comma-separated values that you want to exclude for block device path filter",
 			Destination: &opt.PathFilter,
 		},
+		&cli.Int64Flag{
+			Name:        "rescan-interval",
+			Usage:       "Specify the interval of device rescanning of the node (in seconds)",
+			Destination: &opt.RescanInterval,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -45,7 +45,6 @@ type Info interface {
 
 type infoImpl struct {
 	ctx        *context.Context
-	Disks      []*Disk      `json:"disks"`
 	Partitions []*Partition `json:"-"`
 }
 
@@ -65,20 +64,12 @@ func New() (Info, error) {
 		ctx = context.New()
 	}
 	info := &infoImpl{ctx: ctx}
-	if err := ctx.Do(info.load); err != nil {
-		return nil, err
-	}
 	return info, nil
 }
 
-func (i *infoImpl) load() error {
-	paths := linuxpath.New(i.ctx)
-	i.Disks = disks(i.ctx, paths)
-	return nil
-}
-
 func (i *infoImpl) GetDisks() []*Disk {
-	return i.Disks
+	paths := linuxpath.New(i.ctx)
+	return disks(i.ctx, paths)
 }
 
 func (i *infoImpl) GetPartitions() []*Partition {

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -12,4 +12,5 @@ type Option struct {
 	ProfilerAddress string
 	VendorFilter    string
 	PathFilter      string
+	RescanInterval  int64
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -13,4 +13,5 @@ type Option struct {
 	VendorFilter    string
 	PathFilter      string
 	RescanInterval  int64
+	AutoGPTGenerate bool
 }

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -130,12 +130,15 @@ func (u *Udev) AddBlockDevice(device *v1beta1.BlockDevice, duration time.Duratio
 	devPath := device.Spec.DevPath
 	logrus.Debugf("uevent add block deivce %s", devPath)
 
-	newDevice, err := u.controller.MakeGPTPartitionIfNeeded(device)
+	var err error
+	device, err = u.controller.MakeGPTPartitionIfNeeded(device)
 	if err != nil {
 		return
 	}
-	if newDevice != nil {
-		device = newDevice
+
+	if device == nil {
+		logrus.Infof("Skip adding non-identifiable block device %s", devPath)
+		return
 	}
 
 	bdList, err := u.controller.BlockdeviceCache.List(u.namespace, labels.Everything())


### PR DESCRIPTION
## What

Add periodic rescanning for blockdevices
                                                                     
- A new CLI flag `--rescan-interval`. Default to 60 seconds (feel free to discuss the default in comments)
- A simple periodic blockdevice rescanning mechanism that reuses the
  logic from good old `RegisterNodeBlockDevices` function

## Test plan 

1. Create a k8s cluster with longhorn installed.
2. Run the binary. e.g.`go run main.go`. Don't forget to specify `--namespace` and `--node-name`.
    - You can add `--rescan-interval` with a small value, say `10` seconds, to watch the changes more efficiently.
3. Watch the changes of all blockdevice CR. 
3. Plug a raw disk (without any partition) on the machine
    - Expect to see some block device CR being created.
4. Manually create or delete GPT partitions
    - Expect to see the block device CR being created and delete at each rescan interval.