### PR TITLE
Perform operations only on the node NDM located

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func run(opt *option.Option) error {
 		// 2. add node actions, i.e. block device rescan
 
 		// register to monitor the UDEV events, similar to run `udevadm monitor -u`
-		go udev.NewUdev(block, disks.Harvesterhci().V1beta1().BlockDevice(), opt, filters).Monitor(ctx)
+		go udev.NewUdev(lhs.Longhorn().V1beta1().Node(), disks.Harvesterhci().V1beta1().BlockDevice(), block, opt, filters).Monitor(ctx)
 	})
 
 	<-ctx.Done()

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -159,8 +159,8 @@ func (c *Controller) ScanBlockDevicesOnNode() error {
 // OnBlockDeviceChange watch the block device CR on change and performing disk operations
 // like mounting the disks to a desired path via ext4
 func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice) (*diskv1.BlockDevice, error) {
-	if device == nil || device.DeletionTimestamp != nil {
-		return device, nil
+	if device == nil || device.DeletionTimestamp != nil || device.Spec.NodeName != c.NodeName {
+		return nil, nil
 	}
 
 	deviceCpy := device.DeepCopy()

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pilebones/go-udev/netlink"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -141,7 +142,9 @@ func (u *Udev) AddBlockDevice(device *v1beta1.BlockDevice, duration time.Duratio
 		return
 	}
 
-	bdList, err := u.controller.BlockdeviceCache.List(u.namespace, labels.Everything())
+	bdList, err := u.controller.BlockdeviceCache.List(u.namespace, labels.SelectorFromSet(map[string]string{
+		v1.LabelHostname: u.nodeName,
+	}))
 	if err != nil {
 		logrus.Errorf("Failed to add block device via udev event, error: %s, retry in %s", err.Error(), 2*duration)
 		u.AddBlockDevice(device, 2*duration)

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/harvester/node-disk-manager/pkg/controller/blockdevice"
 	"github.com/harvester/node-disk-manager/pkg/filter"
 	ctldiskv1 "github.com/harvester/node-disk-manager/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	ctllonghornv1 "github.com/harvester/node-disk-manager/pkg/generated/controllers/longhorn.io/v1beta1"
 	"github.com/harvester/node-disk-manager/pkg/option"
 )
 
@@ -34,12 +35,17 @@ type Udev struct {
 	controller *blockdevice.Controller
 }
 
-func NewUdev(block block.Info, blockdevices ctldiskv1.BlockDeviceController, opt *option.Option, filters []*filter.Filter) *Udev {
+func NewUdev(nodes ctllonghornv1.NodeController, bds ctldiskv1.BlockDeviceController, block block.Info, opt *option.Option, filters []*filter.Filter) *Udev {
 	controller := &blockdevice.Controller{
+		Namespace:        opt.Namespace,
+		NodeName:         opt.NodeName,
+		NodeCache:        nodes.Cache(),
+		Nodes:            nodes,
+		Blockdevices:     bds,
+		BlockdeviceCache: bds.Cache(),
 		BlockInfo:        block,
-		Blockdevices:     blockdevices,
-		BlockdeviceCache: blockdevices.Cache(),
 		Filters:          filters,
+		AutoGPTGenerate:  opt.AutoGPTGenerate,
 	}
 	return &Udev{
 		startOnce:  sync.Once{},


### PR DESCRIPTION
## Problem

When attaching/detaching/provisioning device from one node, it deletes blockdevices on other nodes.

## Approaches

In order to let each NDM instance perform operations only on its own node, we did following changes:

- Filter blockdevice by label "kubernetes.io/hostname" on blockdevice to
  avoid NDM from accidentally modifying other nodes' resources.
- Provide valid args to construct blockdevice.controller for udev
  We need to provide all valid args to blockdevice.controller in order to
  let it work correctly. Therefore we need to
    - Expose all fields of `blockdevice.controller`
    - Modify `udev.NewUdev` signature to accept longhorn Node controller
- NDM now only concern blockdevice on the same node.
- Remove leader election (copied from #7)

This PR also fixed the update loop as well (11e05ac)
