### PR TITLE
Able to exclude partition based on ext filesystem label

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,12 @@ func main() {
 			Usage:       "A string of comma-separated values that you want to exclude for block device path filter",
 			Destination: &opt.PathFilter,
 		},
+		&cli.StringFlag{
+			Name:        "label-filter",
+			EnvVars:     []string{"NDM_LABEL_FILTER"},
+			Usage:       "A string of comma-separated glob pattern that you want to exclude for block device filesystem label filter",
+			Destination: &opt.LabelFilter,
+		},
 		&cli.Int64Flag{
 			Name:        "rescan-interval",
 			EnvVars:     []string{"NDM_RESCAN_INTERVAL"},
@@ -184,7 +190,7 @@ func run(opt *option.Option) error {
 		return fmt.Errorf("error building node-disk-manager controllers: %s", err.Error())
 	}
 
-	filters := filter.SetNDMFilters(opt.VendorFilter, opt.PathFilter)
+	filters := filter.SetNDMFilters(opt.VendorFilter, opt.PathFilter, opt.LabelFilter)
 
 	start := func(ctx context.Context) {
 		err = blockdevicev1.Register(ctx, lhs.Longhorn().V1beta1().Node(), disks.Harvesterhci().V1beta1().BlockDevice(), block, opt, filters)

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -272,8 +272,10 @@ func diskPartition(ctx *context.Context, paths *linuxpath.Paths, disk, fname str
 	mp, pt, ro := partitionInfo(ctx, paths, fname)
 	du := GetDiskUUID(fname, string(PartUUID))
 	driveType, storageController := diskTypes(fname)
+	label := GetFileSystemLabel(fname)
 	return &Partition{
 		Name:      fname,
+		Label:     label,
 		SizeBytes: size,
 		FileSystemInfo: FileSystemInfo{
 			MountPoint: mp,

--- a/pkg/block/util.go
+++ b/pkg/block/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 func GetParentDevName(devPath string) (string, error) {
@@ -23,6 +25,29 @@ func GetParentDevName(devPath string) (string, error) {
 
 	return strings.TrimSuffix(string(out), "\n"), nil
 }
+
 func HasPartitions(disk *Disk) bool {
 	return len(disk.Partitions) > 0
+}
+
+func GetFileSystemLabel(devPath string) string {
+	if !strings.HasPrefix(devPath, "/dev") {
+		devPath = "/dev/" + devPath
+	}
+	args := []string{
+		"lsblk",
+		"-no",
+		"label",
+		devPath,
+	}
+	out, err := exec.Command(args[0], args[1:]...).Output()
+	if err != nil {
+		logrus.Warnf("failed to get filesystem label for device %s, %s", devPath, err.Error())
+		return ""
+	}
+	splited := strings.SplitN(string(out), "\n", 2)
+	if len(splited) > 0 {
+		return splited[0]
+	}
+	return ""
 }

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -100,7 +100,7 @@ func (c *Controller) ScanBlockDevicesOnNode() error {
 	// list all the block devices
 	for _, disk := range c.BlockInfo.GetDisks() {
 		// ignore block device by filters
-		if c.ApplyFilter(disk) {
+		if c.ApplyDiskFilter(disk) {
 			continue
 		}
 
@@ -638,10 +638,11 @@ func (c *Controller) OnBlockDeviceDelete(key string, device *diskv1.BlockDevice)
 	return nil, nil
 }
 
-// ApplyFilter check the status of every register filters if the disk meets the filter criteria it will return true else it will return false
-func (c *Controller) ApplyFilter(disk *block.Disk) bool {
+// ApplyDiskFilter check the status of every register filters if the disk meets
+// the filter criteria it will return true else it will return false
+func (c *Controller) ApplyDiskFilter(disk *block.Disk) bool {
 	for _, filter := range c.Filters {
-		if filter.ApplyFilter(disk) {
+		if filter.ApplyDiskFilter(disk) {
 			logrus.Debugf("block device /dev/%s ignored by %s", disk.Name, filter.Name)
 			return true
 		}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -12,13 +12,14 @@ type Filter struct {
 	PartFilter PartFilter
 }
 
-func SetNDMFilters(vendorString, pathString string) []*Filter {
+func SetNDMFilters(vendorString, pathString, labelString string) []*Filter {
 	logrus.Info("register ndm filters")
 	listFilter := make([]*Filter, 0)
 
 	vendorFilter := RegisterVendorFilter(vendorString)
 	pathFilter := RegisterPathFilter(pathString)
-	listFilter = append(listFilter, vendorFilter, pathFilter)
+	labelFilter := RegisterLabelFilter(labelString)
+	listFilter = append(listFilter, vendorFilter, pathFilter, labelFilter)
 
 	return listFilter
 }
@@ -39,6 +40,7 @@ func (f *Filter) ApplyDiskFilter(disk *block.Disk) bool {
 	}
 	return false
 }
+
 func (f *Filter) ApplyPartFilter(part *block.Partition) bool {
 	if f.PartFilter != nil {
 		return f.PartFilter.Exclude(part)

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Filter struct {
-	Name      string
-	Interface Interface
+	Name       string
+	DiskFilter DiskFilter
+	PartFilter PartFilter
 }
 
 func SetNDMFilters(vendorString, pathString string) []*Filter {
@@ -22,14 +23,25 @@ func SetNDMFilters(vendorString, pathString string) []*Filter {
 	return listFilter
 }
 
-type Interface interface {
-	Filters
+type DiskFilter interface {
+	// Exclude returns true if passing disk does not match with exclude value
+	Exclude(disk *block.Disk) bool
 }
 
-type Filters interface {
-	Exclude(disk *block.Disk) bool // exclude returns true if passing disk does not match with exclude value
+type PartFilter interface {
+	// Exclude returns true if passing partition does not match with exclude value
+	Exclude(part *block.Partition) bool
 }
 
-func (f *Filter) ApplyFilter(disk *block.Disk) bool {
-	return f.Interface.Exclude(disk)
+func (f *Filter) ApplyDiskFilter(disk *block.Disk) bool {
+	if f.DiskFilter != nil {
+		return f.DiskFilter.Exclude(disk)
+	}
+	return false
+}
+func (f *Filter) ApplyPartFilter(part *block.Partition) bool {
+	if f.PartFilter != nil {
+		return f.PartFilter.Exclude(part)
+	}
+	return false
 }

--- a/pkg/filter/label_filter.go
+++ b/pkg/filter/label_filter.go
@@ -1,0 +1,51 @@
+package filter
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/harvester/node-disk-manager/pkg/block"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	labelFilterName = "label filter"
+)
+
+// labelFilter filters disk based on given filesystem label patterns
+type labelFilter struct {
+	excludeLabels []string
+}
+
+func RegisterLabelFilter(filters string) *Filter {
+	vf := &labelFilter{}
+
+	vf.excludeLabels = []string{}
+
+	if filters != "" {
+		vf.excludeLabels = append(vf.excludeLabels, strings.Split(filters, ",")...)
+	}
+
+	return &Filter{
+		Name:       labelFilterName,
+		PartFilter: vf,
+	}
+}
+
+// Exclude returns true if filesystem label matches the pattern
+func (vf *labelFilter) Exclude(part *block.Partition) bool {
+	for _, pattern := range vf.excludeLabels {
+		if pattern == "" || part.Label == "" {
+			return false
+		}
+		ok, err := filepath.Match(pattern, part.Label)
+		if err != nil {
+			logrus.Errorf("failed to perform filesystem label matching on disk %s for pattern %s: %s", part.Name, pattern, err.Error())
+			return true
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/filter/path_filter.go
+++ b/pkg/filter/path_filter.go
@@ -31,8 +31,8 @@ func RegisterPathFilter(filters string) *Filter {
 		vf.excludePaths = append(vf.excludePaths, strings.Split(filters, ",")...)
 	}
 	return &Filter{
-		Name:      pathFilterName,
-		Interface: vf,
+		Name:       pathFilterName,
+		DiskFilter: vf,
 	}
 }
 

--- a/pkg/filter/vendor_filter.go
+++ b/pkg/filter/vendor_filter.go
@@ -32,8 +32,8 @@ func RegisterVendorFilter(filters string) *Filter {
 	}
 
 	return &Filter{
-		Name:      vendorFilterName,
-		Interface: vf,
+		Name:       vendorFilterName,
+		DiskFilter: vf,
 	}
 }
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -12,6 +12,7 @@ type Option struct {
 	ProfilerAddress string
 	VendorFilter    string
 	PathFilter      string
+	LabelFilter     string
 	RescanInterval  int64
 	AutoGPTGenerate bool
 }

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -115,7 +115,7 @@ func (u *Udev) ActionHandler(uevent netlink.UEvent) {
 		bd = blockdevice.GetPartitionBlockDevice(part, u.nodeName, u.namespace)
 	}
 
-	if u.controller.ApplyFilter(disk) {
+	if u.controller.ApplyDiskFilter(disk) {
 		return
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/1282

- Separate filter to two filter interface: DiskFilter and PartFilter
- Add new label filter which excludes partition based on given pattern of filesystem label
- Add new cli arg `--label-filter` and new environment variable `NDM_LABEL_FILTER`. It accept a comma separated glob patterns describing in [`path/filepath#Match`](https://pkg.go.dev/path/filepath#Match)

## Following tasks after merged.

- [ ] Update helm chart for harvester/charts repo https://github.com/harvester/charts/pull/34
- [ ] For harvester-installer, add a new value to exclude `COS_*` label https://github.com/harvester/harvester-installer/pull/140

## Test plan

> You can test the docker image at [`weihanglo/node-disk-manager:label-filter`](https://hub.docker.com/layers/169481236/weihanglo/node-disk-manager/label-filter/images/sha256-8a73fe7d2bf56f6b4fa383154f5eb90f097a8838c956080df89825f833d96f45)

1. Run node-disk-manager with `--label-filter` arg, e.g. `--label-filter "COS_*"` to exclude partition with ext label starting with `COS_` prefix
2. Label your partition with that label, e.g. `e2label /dev/sda1 MY_LABEL_*`
3. You shall see that periodic scanning removes partitions matching that filter value.

