### PR TITLE
Do not provision raw disk after force formatting

### DIFF
--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/option"
 	"github.com/jaypipes/ghw/pkg/util"
 	iscsiutil "github.com/longhorn/go-iscsi-helper/util"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/blake2b"
 
 	ndmutil "github.com/harvester/node-disk-manager/pkg/util"
@@ -532,6 +533,7 @@ func GeneratePartitionGUID(part *Partition, nodeName string) string {
 	if valueExists(part.UUID) {
 		return makeHashGUID(nodeName + part.UUID)
 	}
+	logrus.Warnf("failed to generate GUID for device %s", part.Name)
 	return ""
 }
 
@@ -548,6 +550,7 @@ func GenerateDiskGUID(disk *Disk, nodeName string) string {
 	if valueExists(id) {
 		return makeHashGUID(nodeName + id)
 	}
+	logrus.Warnf("failed to generate GUID for device %s", disk.Name)
 	return ""
 }
 

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -126,7 +126,7 @@ func (c *Controller) ScanBlockDevicesOnNode() error {
 		for _, part := range disk.Partitions {
 			logrus.Debugf("Found a partition block device /dev/%s", part.Name)
 			bd := GetPartitionBlockDevice(part, c.NodeName, c.Namespace)
-			if len(bd.Name) == 0 {
+			if bd.Name == "" {
 				logrus.Infof("Skip adding non-identifiable block device %s", bd.Spec.DevPath)
 				continue
 			}
@@ -318,7 +318,7 @@ func updateDeviceMount(devPath, mountPoint, existingMount string) error {
 // Currently only making GPT partition on devices without a name (GUID).
 func (c *Controller) MakeGPTPartitionIfNeeded(device *diskv1.BlockDevice) (*diskv1.BlockDevice, error) {
 	devPath := device.Spec.DevPath
-	guidMissing := len(device.ObjectMeta.Name) == 0
+	guidMissing := device.ObjectMeta.Name == ""
 
 	if !guidMissing {
 		// No need to generate new GPT partition if this device is identifiable.

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -123,6 +123,10 @@ func (c *Controller) ScanBlockDevicesOnNode() error {
 		for _, part := range disk.Partitions {
 			logrus.Debugf("Found a partition block device /dev/%s", part.Name)
 			bd := GetPartitionBlockDevice(part, c.NodeName, c.Namespace)
+			if len(bd.Name) == 0 {
+				logrus.Infof("Skip adding non-identifiable block device %s", bd.Spec.DevPath)
+				continue
+			}
 			newBds = append(newBds, bd)
 		}
 	}

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -335,8 +335,7 @@ func (c *Controller) MakeGPTPartitionIfNeeded(device *diskv1.BlockDevice) (*disk
 		// No device.Name means no WWN nor filesystem UUID for this device.
 		// To identify this device uniquely, we create a GPT table for it.
 		if err := disk.MakeGPTPartition(devPath); err != nil {
-			logrus.Errorf("failed to make GPT parition table for block device %s, error: %v", devPath, err)
-			return nil, err
+			return nil, fmt.Errorf("failed to make GPT partition table for block device %s, error: %v", devPath, err)
 		}
 	}
 	blockDisk := c.BlockInfo.GetDiskByDevPath(devPath)
@@ -430,7 +429,6 @@ func (c *Controller) forceFormatDisk(device *diskv1.BlockDevice) (*diskv1.BlockD
 	diskv1.DeviceFormatting.SetStatusBool(toUpdate, true)
 	diskv1.DeviceFormatting.Message(toUpdate, fmt.Sprintf("formatting disk partition %s with ext4 filesystem", toUpdate.Spec.DevPath))
 	if _, err := c.Blockdevices.Update(toUpdate); err != nil {
-		logrus.Errorf("failed to update partition block device %s, %s", bd.Name, err.Error())
 		return device, err
 	}
 

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -504,7 +504,7 @@ func (c *Controller) SaveBlockDevice(bd *diskv1.BlockDevice, oldBds map[string]*
 		if lastFormatted != nil && newStatus.FileSystem.LastFormattedAt == nil {
 			newStatus.FileSystem.LastFormattedAt = lastFormatted
 		}
-		if !reflect.DeepEqual(oldStatus, newStatus) {
+		if !reflect.DeepEqual(oldStatus, newStatus) || oldBd.Status.State != diskv1.BlockDeviceActive {
 			logrus.Infof("Update existing block device status %s with devPath: %s", oldBd.Name, oldBd.Spec.DevPath)
 			toUpdate := oldBd.DeepCopy()
 			toUpdate.Status.State = diskv1.BlockDeviceActive

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -349,9 +349,6 @@ func (c *Controller) MakeGPTPartitionIfNeeded(device *diskv1.BlockDevice) (*disk
 // - umount the block device if it is mounted
 // - create ext4 filesystem formatting of the single partition
 func (c *Controller) forceFormatPartition(device *diskv1.BlockDevice) (*diskv1.BlockDevice, error) {
-	if diskv1.DeviceFormatting.IsTrue(device) {
-		return device, fmt.Errorf("device %s is already under formatting process ", device.Name)
-	}
 	if device.Status.DeviceStatus.Details.DeviceType != diskv1.DeviceTypePart {
 		return device, fmt.Errorf("device %s is not a partition", device.Name)
 	}

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -359,6 +359,7 @@ func (c *Controller) forceFormatDisk(device *diskv1.BlockDevice) (*diskv1.BlockD
 		part := c.BlockInfo.GetPartitionByDevPath(device.Spec.DevPath, device.Spec.DevPath+"1")
 		partitionBlockDevice := GetPartitionBlockDevice(part, c.NodeName, c.Namespace)
 		partitionBlockDevice.Spec.FileSystem.MountPoint = filesystem.MountPoint
+		partitionBlockDevice.Spec.FileSystem.Provisioned = filesystem.Provisioned
 		partitionBlockDevice.Spec.FileSystem.ForceFormatted = true
 		bd, err := c.BlockdeviceCache.Get(device.Namespace, partitionBlockDevice.Name)
 		diskv1.DeviceFormatting.SetStatusBool(partitionBlockDevice, true)
@@ -386,6 +387,7 @@ func (c *Controller) forceFormatDisk(device *diskv1.BlockDevice) (*diskv1.BlockD
 
 		}
 		device.Spec.FileSystem.MountPoint = ""
+		device.Spec.FileSystem.Provisioned = false
 		device.Status.DeviceStatus.Partitioned = true
 	}
 

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	blockDeviceHandlerName  = "harvester-block-device-handler"
-	defaultRescanInterval   = 1 * time.Minute
+	defaultRescanInterval   = 30 * time.Second
 	forceFormatPollInterval = 3 * time.Second
 	forceFormatPollTimeout  = 30 * time.Second
 )


### PR DESCRIPTION
Related to https://github.com/harvester/harvester/issues/1285

After force formatting a raw disk (e.g. without any partition such as `/dev/sda`), set `spec.fileSystem.provisioned` to false as we do want to provision it single root partition instead of the raw disk itself.