### PR TITLE
Display version in log on application start

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func initLogs(opt *option.Option) {
 		logrus.SetFormatter(&logrus.TextFormatter{})
 	}
 	logrus.SetOutput(os.Stdout)
+	logrus.Infof("Node Disk Manager %s is starting", version.FriendlyVersion())
 	if opt.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)

--- a/scripts/build
+++ b/scripts/build
@@ -9,8 +9,10 @@ mkdir -p bin
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
-LINKFLAGS="-X github.com/rancher/node-disk-manager/pkg/version.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/node-disk-manager/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
+
+LINKFLAGS="-X github.com/harvester/node-disk-manager/pkg/version.Version=$VERSION
+           -X github.com/harvester/node-disk-manager/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
+
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/node-disk-manager
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/node-disk-manager-darwin


### PR DESCRIPTION
The change also fixes the problem that version variables are not
passed during building.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>