### PR TITLE
Exclude disks that contains longhorn in their busPath

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -610,7 +610,7 @@ func (c *Controller) SaveBlockDevice(
 			toUpdate.Status.State = diskv1.BlockDeviceActive
 			toUpdate.Status.DeviceStatus = newStatus
 			if autoProvisioned {
-				provision(bd)
+				provision(toUpdate)
 			}
 			return c.Blockdevices.Update(toUpdate)
 		}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -275,8 +275,8 @@ func Test_vendorFilter(t *testing.T) {
 		{
 			name: "longhorn bus path",
 			given: input{
-				disk:    &block.Disk{Vendor: "yourvendor", BusPath: "longhorn"},
-				vendors: []string{"longhorn"},
+				disk:    &block.Disk{BusPath: "ip-10.52.0.122:3260-iscsi-iqn.2019-10.io.longhorn:pvc-ab9af96e-60ef-400f-84f7-2f6eab68ab56-lun-1"},
+				vendors: []string{"LongHorN"},
 			},
 			expected: true,
 		},

--- a/pkg/filter/path_filter.go
+++ b/pkg/filter/path_filter.go
@@ -41,7 +41,7 @@ func (f *partPathFilter) Match(part *block.Partition) bool {
 	if part.FileSystemInfo.MountPoint == "" {
 		return false
 	}
-	return util.ContainsIgnoredCase(f.mountPaths, part.FileSystemInfo.MountPoint)
+	return util.MatchesIgnoredCase(f.mountPaths, part.FileSystemInfo.MountPoint)
 }
 
 // Match returns true if mount path of the disk is matched
@@ -49,5 +49,5 @@ func (f *diskPathFilter) Match(disk *block.Disk) bool {
 	if disk.FileSystemInfo.MountPoint == "" {
 		return false
 	}
-	return util.ContainsIgnoredCase(f.mountPaths, disk.FileSystemInfo.MountPoint)
+	return util.MatchesIgnoredCase(f.mountPaths, disk.FileSystemInfo.MountPoint)
 }

--- a/pkg/filter/vendor_filter.go
+++ b/pkg/filter/vendor_filter.go
@@ -33,9 +33,8 @@ func RegisterVendorFilter(filters ...string) *Filter {
 
 // Match returns true if vendor of the disk is matched
 func (vf *vendorFilter) Match(blockDevice *block.Disk) bool {
-	if blockDevice.Vendor == "" && blockDevice.BusPath == "" {
-		return false
+	if blockDevice.Vendor != "" && util.MatchesIgnoredCase(vf.vendors, blockDevice.Vendor) {
+		return true
 	}
-	return util.ContainsIgnoredCase(vf.vendors, blockDevice.Vendor) ||
-		util.ContainsIgnoredCase(vf.vendors, blockDevice.BusPath)
+	return blockDevice.BusPath != "" && util.ContainsIgnoredCase(vf.vendors, blockDevice.BusPath)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -42,9 +42,19 @@ func GetDiskPartitionPath(devicePath string, partitionNum int) string {
 	return fmt.Sprintf("%s%s%d", devicePath, partitionSep, partitionNum)
 }
 
-func ContainsIgnoredCase(s []string, k string) bool {
+func MatchesIgnoredCase(s []string, k string) bool {
 	for _, e := range s {
 		if strings.EqualFold(e, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsIgnoredCase(s []string, k string) bool {
+	k = strings.ToLower(k)
+	for _, e := range s {
+		if strings.Contains(k, strings.ToLower(e)) {
 			return true
 		}
 	}


### PR DESCRIPTION
`ContainsIgnoredCase` is actually `MatchesIgnoredCase`, so we create
another `MatchesIgnoredCase` to do the real job.

This PR also includes a tiny fix for updating the right blockdevice.