### PR TITLE
New `pathTypeFilter` to exclude BIOS boot partition

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -34,6 +34,7 @@ type Partition struct {
 	Label             string                  `json:"label"`
 	SizeBytes         uint64                  `json:"size_bytes"`
 	UUID              string                  `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	PartType          string                  `json:"part_type"`
 	DriveType         block.DriveType         `json:"drive_type"`
 	StorageController block.StorageController `json:"storage_controller"`
 	FileSystemInfo    FileSystemInfo          `json:"file_system_info"`

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -273,6 +273,7 @@ func diskPartition(ctx *context.Context, paths *linuxpath.Paths, disk, fname str
 	du := GetDiskUUID(fname, string(PartUUID))
 	driveType, storageController := diskTypes(fname)
 	label := GetFileSystemLabel(fname)
+	partType := GetPartType(fname)
 	return &Partition{
 		Name:      fname,
 		Label:     label,
@@ -283,6 +284,7 @@ func diskPartition(ctx *context.Context, paths *linuxpath.Paths, disk, fname str
 			IsReadOnly: ro,
 		},
 		UUID:              du,
+		PartType:          partType,
 		DriveType:         driveType,
 		StorageController: storageController,
 	}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -36,7 +36,9 @@ func SetExcludeFilters(vendorString, pathString, labelString string) []*Filter {
 	labels := strings.Split(labelString, ",")
 	labelFilter := RegisterLabelFilter(labels...)
 
-	return []*Filter{vendorFilter, pathFilter, labelFilter}
+	partTypeFilters := RegisterPartTypeFilter(defaultExcludedPartTypes...)
+
+	return []*Filter{vendorFilter, pathFilter, labelFilter, partTypeFilters}
 }
 
 type DiskFilter interface {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -290,3 +290,84 @@ func Test_vendorFilter(t *testing.T) {
 		})
 	}
 }
+func Test_partTypeFilter(t *testing.T) {
+	type input struct {
+		part      *block.Partition
+		disk      *block.Disk
+		partTypes []string
+	}
+	var testCases = []struct {
+		name     string
+		given    input
+		expected bool
+	}{
+		{
+			name: "valid partition and matched parttype",
+			given: input{
+				part: &block.Partition{
+					PartType: "match",
+				},
+				partTypes: []string{"match"},
+			},
+			expected: true,
+		},
+		{
+			name: "empty partition and matched parttype",
+			given: input{
+				part:      &block.Partition{},
+				partTypes: []string{"match"},
+			},
+			expected: false,
+		},
+		{
+			name: "valid partition and empty parttype",
+			given: input{
+				part: &block.Partition{
+					PartType: "match",
+				},
+				partTypes: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "valid partition and valid parttype but mismatch",
+			given: input{
+				part: &block.Partition{
+					PartType: "match",
+				},
+				partTypes: []string{"mismatch"},
+			},
+			expected: false,
+		},
+		{
+			name: "valid disk with partition that matches parttype",
+			given: input{
+				disk:      &block.Disk{Partitions: []*block.Partition{{PartType: "match"}}},
+				partTypes: []string{"match"},
+			},
+			expected: true,
+		},
+		{
+			name: "valid disk with partition that mismatches parttype",
+			given: input{
+				disk:      &block.Disk{Partitions: []*block.Partition{{PartType: "match"}}},
+				partTypes: []string{"mismatch"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := RegisterPartTypeFilter(tc.given.partTypes...)
+			if tc.given.part != nil {
+				result := filter.ApplyPartFilter(tc.given.part)
+				assert.Equal(t, tc.expected, result)
+			}
+			if tc.given.disk != nil {
+				result := filter.ApplyDiskFilter(tc.given.disk)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/filter/part_type_filter.go
+++ b/pkg/filter/part_type_filter.go
@@ -1,0 +1,57 @@
+package filter
+
+import (
+	"github.com/harvester/node-disk-manager/pkg/block"
+	"github.com/harvester/node-disk-manager/pkg/util"
+)
+
+const (
+	partTypeFilterName = "parttype filter"
+	partTypeBIOSBoot   = "21686148-6449-6E6F-744E-656564454649"
+)
+
+var (
+	defaultExcludedPartTypes = []string{partTypeBIOSBoot}
+)
+
+// partPartTypeFilter filters disk based on given part type, e.g., BIOS boot.
+type partPartTypeFilter struct {
+	partType []string
+}
+
+// diskPartTypeFilter filters disk if any of its partitions matches given part type.
+type diskPartTypeFilter struct {
+	filter *partPartTypeFilter
+}
+
+func RegisterPartTypeFilter(filters ...string) *Filter {
+	f := &partPartTypeFilter{}
+	for _, filter := range filters {
+		if filter != "" {
+			f.partType = append(f.partType, filter)
+		}
+	}
+	return &Filter{
+		Name:       partTypeFilterName,
+		PartFilter: f,
+		DiskFilter: &diskPartTypeFilter{filter: f},
+	}
+}
+
+// Match returns true if partition matches given part types.
+func (f *partPartTypeFilter) Match(part *block.Partition) bool {
+	if part.PartType == "" {
+		return false
+	}
+	return util.MatchesIgnoredCase(f.partType, part.PartType)
+}
+
+// Match returns true if any of its partitions matches.
+func (f *diskPartTypeFilter) Match(disk *block.Disk) bool {
+	for _, part := range disk.Partitions {
+		if f.filter.Match(part) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/filter/path_filter.go
+++ b/pkg/filter/path_filter.go
@@ -30,7 +30,7 @@ func RegisterPathFilter(filters ...string) *Filter {
 		}
 	}
 	return &Filter{
-		Name:       pathFilterName,
+		Name:       partTypeFilterName,
 		PartFilter: f,
 		DiskFilter: &diskPathFilter{mountPaths: f.mountPaths},
 	}


### PR DESCRIPTION
Related: harvester/harvester#1382, harvester/harvester#1241

## Solution

Introduce a new `pathTypeFilter`.

Partition like BIOS boot in GPT scheme should not be provisioned.
So do the parent disk of that partition. Thus, if any partition matches
excluded parttype, both the partition and its parent disk get excluded.
