### PR TITLE
Fix reconcile enqueue

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -232,6 +232,10 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 		}
 	}
 
+	if err := c.updateFileSystemStatus(deviceCpy); err != nil {
+		return device, err
+	}
+
 	if device.Status.DeviceStatus.Details.DeviceType == diskv1.DeviceTypePart {
 		switch {
 		case fs.MountPoint != "" && fs.Provisioned:
@@ -253,10 +257,6 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 				}
 			}
 		}
-	}
-
-	if err := c.updateFileSystemStatus(deviceCpy); err != nil {
-		return device, err
 	}
 
 	if !reflect.DeepEqual(device, deviceCpy) {


### PR DESCRIPTION
Related: harvester/harvester#1599

Callback reenqueue: node-disk-manager migth be deployed earlier than Longhorn. Thus, if NDM cannot find longhorn node to provision, it should re-enqueue the callback after 15s.


## Test Plan

Refer to harvester/harvester#1599. 

You can 

1. deploy the first node, and then 
2. change the `--auto-provision-filter` arg for demonset/harvester-node-disk-manager to whatever you want to provision. 
3. Last, create a new join-cluster with disks matching that auto-provision pattern.