### PR TITLE
Retrieve filesytem info based on fs UUID

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -33,7 +33,8 @@ type Partition struct {
 	Name              string                  `json:"name"`
 	Label             string                  `json:"label"`
 	SizeBytes         uint64                  `json:"size_bytes"`
-	UUID              string                  `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	UUID              string                  `json:"uuid"`    // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	FsUUID            string                  `json:"fs_uuid"` // This would be filesystem UUID on macOS and linux, empty on Windows
 	PartType          string                  `json:"part_type"`
 	DriveType         block.DriveType         `json:"drive_type"`
 	StorageController block.StorageController `json:"storage_controller"`

--- a/pkg/controller/blockdevice/blockdevice.go
+++ b/pkg/controller/blockdevice/blockdevice.go
@@ -96,6 +96,7 @@ func GetPartitionBlockDevice(part *block.Partition, nodeName, namespace string) 
 				DeviceType:        diskv1.DeviceTypePart,
 				Label:             part.Label,
 				PartUUID:          part.UUID,
+				UUID:              part.FsUUID,
 				DriveType:         part.DriveType.String(),
 				StorageController: part.StorageController.String(),
 			},

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -294,7 +294,8 @@ func ConvertBlockDevicesToMap(bds []*diskv1.BlockDevice) map[string]*diskv1.Bloc
 
 func (c *Controller) updateFileSystemStatus(device *diskv1.BlockDevice) error {
 	// fetch the latest device filesystem info
-	filesystem := c.BlockInfo.GetFileSystemInfoByDevPath(device.Spec.DevPath)
+	uuid := device.Status.DeviceStatus.Details.UUID
+	filesystem := c.BlockInfo.GetFileSystemInfoByFsUUID(uuid)
 	mountPoint := device.Spec.FileSystem.MountPoint
 	device.Status.DeviceStatus.FileSystem.Type = filesystem.Type
 	device.Status.DeviceStatus.FileSystem.IsReadOnly = filesystem.IsReadOnly
@@ -484,7 +485,8 @@ func (c *Controller) forceFormatDisk(device *diskv1.BlockDevice) (*diskv1.BlockD
 
 // provisionDeviceToNode adds a device to longhorn node as an additional disk.
 func (c *Controller) provisionDeviceToNode(device *diskv1.BlockDevice) error {
-	filesystem := c.BlockInfo.GetFileSystemInfoByDevPath(device.Spec.DevPath)
+	uuid := device.Status.DeviceStatus.Details.UUID
+	filesystem := c.BlockInfo.GetFileSystemInfoByFsUUID(uuid)
 	if filesystem == nil || filesystem.MountPoint == "" {
 		// No mount point. Skipping...
 		return nil


### PR DESCRIPTION
Related: harvester/harvester#1829  harvester/harvester#1874

Previously, NDM use device path like `/dev/sda` to retrieve underlying
filesystem info, which is risky because the path is unstable and not
consistent between each boot. In this commit we use filesystem UUID
stored in `blockdevice.Status.DeviceStatus.Details.UUID` to get the
stable filesystem info from UUID.


## Test plan

1. Add an extra disk to a host.
2. provision and unprovision it back-and-forth. The filesystem detection shall work as expected.