### PR TITLE
Support raw block devices provision

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,12 +113,6 @@ func main() {
 			Usage:       "Specify the interval of device rescanning of the node (in seconds)",
 			Destination: &opt.RescanInterval,
 		},
-		&cli.BoolFlag{
-			Name:        "auto-gpt-generate",
-			EnvVars:     []string{"NDM_AUTO_GPT_GENERATE"},
-			Usage:       "Enable auto GPT partition generating if a disk can not be globally identified",
-			Destination: &opt.AutoGPTGenerate,
-		},
 		&cli.StringFlag{
 			Name:        "auto-provision-filter",
 			EnvVars:     []string{"NDM_AUTO_PROVISION_FILTER"},

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -94,13 +94,13 @@ func (i *infoImpl) GetPartitionByDevPath(disk, part string) *Partition {
 
 func (i *infoImpl) GetFileSystemInfoByFsUUID(fsUUID string) *FileSystemInfo {
 	if fsUUID == "" {
-		return &FileSystemInfo{}
+		return nil
 	}
 	// Resolve the symlink to the special block device file
 	dname, err := filepath.EvalSymlinks("/dev/disk/by-uuid/" + fsUUID)
 	if err != nil {
 		logrus.Errorf("failed to get filesystem info for UUID %s: %s", fsUUID, err.Error())
-		return &FileSystemInfo{}
+		return nil
 	}
 	paths := linuxpath.New(i.ctx)
 	mp, pt, ro := partitionInfo(i.ctx, paths, dname)

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -93,7 +93,6 @@ func (i *infoImpl) GetPartitionByDevPath(disk, part string) *Partition {
 }
 
 func (i *infoImpl) GetFileSystemInfoByDevPath(dname string) *FileSystemInfo {
-	dname = strings.TrimPrefix(dname, "/dev/")
 	paths := linuxpath.New(i.ctx)
 	mp, pt, ro := partitionInfo(i.ctx, paths, dname)
 	return &FileSystemInfo{

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -41,7 +41,7 @@ type Info interface {
 	GetPartitions() []*Partition
 	GetDiskByDevPath(name string) *Disk
 	GetPartitionByDevPath(disk, part string) *Partition
-	GetFileSystemInfoByFsUUID(dname string) *FileSystemInfo
+	GetFileSystemInfoByDevPath(dname string) *FileSystemInfo
 }
 
 type infoImpl struct {
@@ -92,16 +92,8 @@ func (i *infoImpl) GetPartitionByDevPath(disk, part string) *Partition {
 	return partition
 }
 
-func (i *infoImpl) GetFileSystemInfoByFsUUID(fsUUID string) *FileSystemInfo {
-	if fsUUID == "" {
-		return nil
-	}
-	// Resolve the symlink to the special block device file
-	dname, err := filepath.EvalSymlinks("/dev/disk/by-uuid/" + fsUUID)
-	if err != nil {
-		logrus.Errorf("failed to get filesystem info for UUID %s: %s", fsUUID, err.Error())
-		return nil
-	}
+func (i *infoImpl) GetFileSystemInfoByDevPath(dname string) *FileSystemInfo {
+	dname = strings.TrimPrefix(dname, "/dev/")
 	paths := linuxpath.New(i.ctx)
 	mp, pt, ro := partitionInfo(i.ctx, paths, dname)
 	return &FileSystemInfo{

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -117,7 +117,7 @@ func (c *Controller) ScanBlockDevicesOnNode() error {
 		bd := GetDiskBlockDevice(disk, c.NodeName, c.Namespace)
 
 		if bd == nil {
-			logrus.Infof("Skip adding non-identifiable block device %s", bd.Spec.DevPath)
+			logrus.Infof("Skip adding non-identifiable block device /dev/%s", disk.Name)
 			continue
 		}
 

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -604,6 +604,9 @@ func resolvePersistentDevPath(device *diskv1.BlockDevice) (string, error) {
 		if wwn == "" {
 			return "", fmt.Errorf("WWN not found on device %s", device.Name)
 		}
+		if device.Status.DeviceStatus.Details.StorageController == string(diskv1.StorageControllerNVMe) {
+			return filepath.EvalSymlinks("/dev/disk/by-id/nvme-" + wwn)
+		}
 		return filepath.EvalSymlinks("/dev/disk/by-id/wwn-" + wwn)
 	case diskv1.DeviceTypePart:
 		partUUID := device.Status.DeviceStatus.Details.PartUUID

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	diskv1 "github.com/harvester/node-disk-manager/pkg/apis/harvesterhci.io/v1beta1"
@@ -142,7 +141,7 @@ func (c *Controller) ScanBlockDevicesOnNode() error {
 		}
 	}
 
-	oldBdList, err := c.Blockdevices.List(c.Namespace, v1.ListOptions{
+	oldBdList, err := c.Blockdevices.List(c.Namespace, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", corev1.LabelHostname, c.NodeName),
 	})
 	if err != nil {

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -271,8 +271,8 @@ func ConvertBlockDevicesToMap(bds []*diskv1.BlockDevice) map[string]*diskv1.Bloc
 
 func (c *Controller) updateDeviceMount(device *diskv1.BlockDevice, devPath string, filesystem *block.FileSystemInfo) error {
 	expectedMountPoint := device.Spec.FileSystem.MountPoint
-	if expectedMountPoint != "" && device.Status.DeviceStatus.Partitioned && diskv1.DeviceMounted.IsTrue(device) {
-		return fmt.Errorf("cannot mount parent device with partitions")
+	if expectedMountPoint != "" && device.Status.DeviceStatus.Partitioned {
+		return fmt.Errorf("cannot mount device with partitions")
 	}
 	// umount the previous path if exist
 	if filesystem != nil && filesystem.MountPoint != "" {

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -4,33 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 )
-
-var gptPartitionOptions = strings.Join([]string{
-	"mklabel",
-	"gpt",
-	"mkpart",
-	"primary",
-	"ext4",
-	"0%",
-	"100%",
-}, " ")
-
-// MakeGPTPartition making GPT partition table and creating partitions using parted in Linux
-func MakeGPTPartition(device string) error {
-	logrus.Infof("make gpt partition of device %s", device)
-	cmd := exec.Command("parted", "-a", "optimal", "-s", device, gptPartitionOptions)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("stderr: %s, err: %s", stderr.String(), err.Error())
-	}
-	return nil
-}
 
 // MakeExt4DiskFormatting create ext4 filesystem formatting of the specified devPath
 func MakeExt4DiskFormatting(devPath string) error {

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -15,5 +15,4 @@ type Option struct {
 	LabelFilter         string
 	AutoProvisionFilter string
 	RescanInterval      int64
-	AutoGPTGenerate     bool
 }

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -52,7 +52,6 @@ func NewUdev(
 		BlockdeviceCache:     bds.Cache(),
 		BlockInfo:            block,
 		ExcludeFilters:       excludeFilters,
-		AutoGPTGenerate:      opt.AutoGPTGenerate,
 		AutoProvisionFilters: autoProvisionFilters,
 	}
 	return &Udev{
@@ -154,17 +153,10 @@ func (u *Udev) AddBlockDevice(device *v1beta1.BlockDevice, duration time.Duratio
 	if duration > defaultDuration {
 		time.Sleep(duration)
 	}
-	devPath := device.Spec.DevPath
-	logrus.Debugf("uevent add block deivce %s", devPath)
+	logrus.Debugf("uevent add block deivce %s", device.Spec.DevPath)
 
-	var err error
-	device, err = u.controller.MakeGPTPartitionIfNeeded(device)
-	if err != nil {
-		return
-	}
-
-	if device == nil {
-		logrus.Infof("Skip adding non-identifiable block device %s", devPath)
+	if device == nil || device.Name == "" {
+		logrus.Infof("Skip adding non-identifiable block device %s", device.Spec.DevPath)
 		return
 	}
 

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -153,12 +153,13 @@ func (u *Udev) AddBlockDevice(device *v1beta1.BlockDevice, duration time.Duratio
 	if duration > defaultDuration {
 		time.Sleep(duration)
 	}
-	logrus.Debugf("uevent add block deivce %s", device.Spec.DevPath)
 
 	if device == nil || device.Name == "" {
 		logrus.Infof("Skip adding non-identifiable block device %s", device.Spec.DevPath)
 		return
 	}
+
+	logrus.Debugf("uevent add block deivce %s", device.Spec.DevPath)
 
 	bdList, err := u.controller.BlockdeviceCache.List(u.namespace, labels.SelectorFromSet(map[string]string{
 		v1.LabelHostname: u.nodeName,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -30,18 +29,6 @@ func GetFullDevPath(shortPath string) string {
 		return ""
 	}
 	return fmt.Sprintf("/dev/%s", shortPath)
-}
-
-func GetDiskPartitionPath(devicePath string, partitionNum int) string {
-	partitionSep := ""
-	last := devicePath[len(devicePath)-1:]
-	if _, err := strconv.Atoi(last); err == nil {
-		// If a disk device name ends with a digit then the Linux Kernel adds
-		// the character 'p' to separate the partition number from the device name.
-		// Example: /dev/nvme0n1 -> /dev/nvme0n1p1
-		partitionSep = "p"
-	}
-	return fmt.Sprintf("%s%s%d", devicePath, partitionSep, partitionNum)
 }
 
 func MatchesIgnoredCase(s []string, k string) bool {


### PR DESCRIPTION
Related: https://github.com/harvester/harvester/issues/1839

Add support to provision raw blocks directly but maintain the ability to provision partitions.

- 58aacbae68295409b8b604ed1f0f0ea99b9efda6 **Remove auto-gpt-generate flag**: We do not provide this feature anymore. Devices are required to have WWN attached in order to uniquely identify by NDM.
- 3fb3e4bdd28789605d41de552c58273af23d4f3f **Remove the auto partition logic**: Raw block device can now be provisioned by NDM to Longhorn directly.
- e1444ae72990965921a17ba74b71ad9d46c918fc **Retrieve realtime filesystem info from OS**: NDM does not rely on CR status anymore to determine filesystem status. Instead, it queries the info from OS directly.
- 43ba0430076e7694bf444522c6b09b817f1c90e3 **Get real devpath from persistent device property**: In #24, NDM started retrieving filesystem info from filesystem UUID. This commit reverts a part of that logic. It's caller's responsibility to provide a correct devPath to `GetFileSystemInfoByDevPath`. In this commit, NDM therefore resolves the real devPath from persistent devPath before calling `GetFileSystemInfoByDevPath`. The `by-id` naming rules is defined in `/usr/lib/udev/rules.d/60-persistent-storage.rules`

## Test plan

#### Raw block device

1. Build NDM and patch the image of daemonset controller
2. Attach a raw block device to the node
3. `kubectl -n longhorn-system edit bd` and set `spec.fileSystem = { provisioned: true, forceFormatted: true, mountPoint: "/path/to/any/valid/mount/point" }`
4. The raw block device shall be schedulable as longhorn disk as a whole (without any partition) and is in `provisioned` phase
5. Set `spec.fileSystem.mountPoint = ""`, the device should be back to `Unprovisioned` phase

#### Partitions

1. Build NDM and patch the image of daemonset controller
2. Attach a raw block device to the node. Then partition the disk into multiple partitions, say, two.
3. `kubectl -n longhorn-system edit bd` and set `spec.fileSystem = { provisioned: true, forceFormatted: true, , mountPoint: "/path/to/any/valid/mount/point" } for all partitions`
4. All partitions shall be schedulable as longhorn disk as a whole (without any partition) and is in `provisioned` phase
5. Set `spec.fileSystem.mountPoint = ""` for all partitions. And then they should be back to `Unprovisioned` phase
