### PR TITLE
Fix race condition by updating resouce correctly

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -216,11 +216,15 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 				// forceFormatDisk may return a new device with new GPT label
 				// If in that case, just return instead of proceeding following update.
 				return newDevice, nil
+			} else {
+				deviceCpy = newDevice
 			}
 		case diskv1.DeviceTypePart:
-			if deviceCpy, err := c.forceFormatPartition(deviceCpy); err != nil {
+			newDevice, err := c.forceFormatPartition(deviceCpy)
+			if err != nil {
 				return updateFormattingErrorCondition(deviceCpy, err)
 			}
+			deviceCpy = newDevice
 		}
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/1718


The root cause of race condition described in harvester/harvester#1718 can be resolved by https://github.com/harvester/harvester/issues/1718#issuecomment-1024114231. Specifically, it is a programming error that forgot to update blockdevice resource after formatting the disk.

This PR also fix the unnecessary update of DeviceMounted condition that causes a infinite update loop.

### Test plan

1. Prepare more than 10 extra disks for you harvester node.
2. Build NDM and update the version of harvester-node-disk-manager to this PR
3. Swipe all data on extra disks.
4. Enable auto-provision on NDM by adding an environment variable of the daemonset controller
  ```yaml
        - name: NDM_AUTO_PROVISION_FILTER
          value: /dev/sd*
  ```
5. Eventually, all disks matching the pattern should be partitioned, formatted and mounted successfully.
6. Check the log with the command `kubectl logs -n harvester-system ds/harvester-node-disk-manager -f`. After all disk being mounted, there should be no logs other than `Scan block devices of node`.

> Note that the partition and format timeout is not handled in this PR. That is a know caveat but does not directly lead to the race condition. We'll address it in the follow-ups.