### PR TITLE
Apply label filter on disks

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -10,6 +10,7 @@ import (
 // raw block storage resources.
 type Disk struct {
 	Name                   string                  `json:"name"`
+	Label                  string                  `json:"label"`
 	SizeBytes              uint64                  `json:"size_bytes"`
 	PhysicalBlockSizeBytes uint64                  `json:"physical_block_size_bytes"`
 	DriveType              block.DriveType         `json:"drive_type"`

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -338,12 +338,19 @@ func getDisk(ctx *context.Context, paths *linuxpath.Paths, dname string) *Disk {
 		IsReadOnly: ro,
 	}
 
+	var label string
+	if uuid != "" {
+		// Only disk with ext4 filesystem UUID can have a label
+		label = GetFileSystemLabel(dname)
+	}
+
 	if fs.Type == "" {
 		fs.Type = GetFileSystemType(dname)
 	}
 
 	d := &Disk{
 		Name:                   dname,
+		Label:                  label,
 		SizeBytes:              size,
 		PhysicalBlockSizeBytes: pbs,
 		DriveType:              driveType,

--- a/pkg/filter/device_path_filter.go
+++ b/pkg/filter/device_path_filter.go
@@ -43,7 +43,7 @@ func (f *partDevicePathFilter) Match(part *block.Partition) bool {
 	if devPath == "" {
 		return false
 	}
-	return match(devPath, f.filter.devicePaths)
+	return matchDevPath(devPath, f.filter.devicePaths)
 }
 
 // Match returns true if given device path matches the pattern.
@@ -52,10 +52,10 @@ func (f *diskDevicePathFilter) Match(disk *block.Disk) bool {
 	if devPath == "" {
 		return false
 	}
-	return match(devPath, f.devicePaths)
+	return matchDevPath(devPath, f.devicePaths)
 }
 
-func match(devPath string, patterns []string) bool {
+func matchDevPath(devPath string, patterns []string) bool {
 	for _, pattern := range patterns {
 		if pattern == "" || devPath == "" {
 			return false


### PR DESCRIPTION
Related: harvester/harvester#1924

## What's inside

After #26, raw block devices are enabled to be provisioned. As a result, label filter cannot filter out raw block since previously it excluded partitions only. This PR reuse the same logic of label filter on disks as well.

- Collect filesytem `LABEL` when a disk has a filesytem on it.
- Apply the same logic of label filter on disks as well.

## Test plan

Copy from the reproducible steps:

1. Install Harvester with default data disk set to a disk different from the OS disk, e.g. /dev/sda
1. Go to "Hosts" page -> Select the node -> "Edit Config" -> "Disks" page -> Click "Add Disk"
1. The default data disk should not in the drop-down list.

Another way to test:

1. Install a Harvester cluster
2. Add a disk. Format it as ext4 filesystem. 
3. Run `e2label /dev/your/disk HARV_MY_DISK`
4. The corresponding blockdevicee CR of your extra disk won't show in the result of `kubectl -n longhorn-system get bd`