### PR TITLE
Remove unused `parted` system packages

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.suse.com/bci/bci-base:15.3
 
-# parted -> for `parted` command
 # util-linux-systemd -> for `lsblk` command
 # e2fsprogs -> for `mkfs.ext4` command
+# iproute2 -> for `ip` command
 RUN zypper -n rm container-suseconnect && \
-    zypper -n install parted util-linux-systemd e2fsprogs iproute2 && \
+    zypper -n install util-linux-systemd e2fsprogs iproute2 && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 
 COPY bin/node-disk-manager /usr/bin/


### PR DESCRIPTION
After #26, node disk manager doesn't perform any partition. This is leftover and should be removed.


Signed-off-by: Weihang Lo <weihang.lo@suse.com>