### PR TITLE
Enforce that only `OnBlockDeviceChange` can update CR

### DIFF
--- a/pkg/block/blkid.go
+++ b/pkg/block/blkid.go
@@ -19,7 +19,7 @@ func GetFileSystemType(part string) string {
 	}
 	out, err := exec.Command(args[0], args[1:]...).Output()
 	if err != nil {
-		logrus.Warnf("failed to read disk uuid of %s : %s\n", part, err.Error())
+		logrus.Debugf("failed to read disk uuid of %s : %s\n", part, err.Error())
 		return ""
 	}
 
@@ -29,7 +29,7 @@ func GetFileSystemType(part string) string {
 
 	parts := strings.Split(string(out), "TYPE=")
 	if len(parts) != 2 {
-		logrus.Warnf("failed to parse the type of %s\n", part)
+		logrus.Debugf("failed to parse the type of %s\n", part)
 		return ""
 	}
 
@@ -48,7 +48,7 @@ func GetDiskUUID(part string, uuidType string) string {
 	}
 	out, err := exec.Command(args[0], args[1:]...).Output()
 	if err != nil {
-		logrus.Warnf("failed to read disk uuid of %s : %s\n", part, err.Error())
+		logrus.Debugf("failed to read disk uuid of %s : %s\n", part, err.Error())
 		return ""
 	}
 
@@ -58,7 +58,7 @@ func GetDiskUUID(part string, uuidType string) string {
 
 	parts := strings.Split(string(out), "UUID=")
 	if len(parts) != 2 {
-		logrus.Warnf("failed to parse the uuid of %s\n", part)
+		logrus.Debugf("failed to parse the uuid of %s\n", part)
 		return ""
 	}
 

--- a/pkg/block/block_device.go
+++ b/pkg/block/block_device.go
@@ -271,8 +271,11 @@ func diskPartition(ctx *context.Context, paths *linuxpath.Paths, disk, fname str
 	mp, pt, ro := partitionInfo(ctx, paths, fname)
 	du := GetDiskUUID(fname, string(PartUUID))
 	fsUUID := GetDiskUUID(fname, string(UUID))
+	var label string
+	if fsUUID != "" {
+		label = GetFileSystemLabel(fname)
+	}
 	driveType, storageController := diskTypes(fname)
-	label := GetFileSystemLabel(fname)
 	partType := GetPartType(fname)
 	return &Partition{
 		Name:      fname,
@@ -545,7 +548,7 @@ func GeneratePartitionGUID(part *Partition, nodeName string) string {
 	if valueExists(part.UUID) {
 		return makeHashGUID(nodeName + part.UUID)
 	}
-	logrus.Warnf("failed to generate GUID for device %s", part.Name)
+	logrus.Debugf("failed to generate GUID for device %s", part.Name)
 	return ""
 }
 
@@ -562,7 +565,7 @@ func GenerateDiskGUID(disk *Disk, nodeName string) string {
 	if valueExists(id) {
 		return makeHashGUID(nodeName + id)
 	}
-	logrus.Warnf("failed to generate GUID for device %s", disk.Name)
+	logrus.Debugf("failed to generate GUID for device %s", disk.Name)
 	return ""
 }
 

--- a/pkg/block/util.go
+++ b/pkg/block/util.go
@@ -19,7 +19,7 @@ func HasPartitions(disk *Disk) bool {
 func GetFileSystemLabel(devPath string) string {
 	result, err := lsblk(devPath, "label")
 	if err != nil {
-		logrus.Warnf(err.Error())
+		logrus.Debugf(err.Error())
 	}
 	return result
 }
@@ -27,7 +27,7 @@ func GetFileSystemLabel(devPath string) string {
 func GetPartType(devPath string) string {
 	result, err := lsblk(devPath, "parttype")
 	if err != nil {
-		logrus.Warnf(err.Error())
+		logrus.Debugf(err.Error())
 	}
 	return result
 }

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -99,7 +99,7 @@ func Register(
 
 // ScanBlockDevicesOnNode scans block devices on the node, and it will either create or update them.
 func (c *Controller) ScanBlockDevicesOnNode() error {
-	logrus.Infof("Scan block devices of node: %s", c.NodeName)
+	logrus.Debugf("Scan block devices of node: %s", c.NodeName)
 	newBds := make([]*diskv1.BlockDevice, 0)
 
 	autoProvisionedMap := make(map[string]bool, 0)
@@ -403,7 +403,7 @@ func (c *Controller) unprovisionDeviceFromNode(device *diskv1.BlockDevice) error
 
 	diskToRemove, ok := node.Spec.Disks[device.Name]
 	if !ok {
-		logrus.Errorf("disk %s not in disks of longhorn node %s/%s", device.Name, c.Namespace, c.NodeName)
+		logrus.Infof("disk %s not in disks of longhorn node %s/%s", device.Name, c.Namespace, c.NodeName)
 		updateProvisionPhaseUnprovisioned()
 		return nil
 	}

--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -1,0 +1,218 @@
+package blockdevice
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	diskv1 "github.com/harvester/node-disk-manager/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/node-disk-manager/pkg/block"
+	"github.com/harvester/node-disk-manager/pkg/filter"
+	ctldiskv1 "github.com/harvester/node-disk-manager/pkg/generated/controllers/harvesterhci.io/v1beta1"
+)
+
+const (
+	defaultRescanInterval = 30 * time.Second
+)
+
+type Scanner struct {
+	NodeName             string
+	Namespace            string
+	Blockdevices         ctldiskv1.BlockDeviceController
+	BlockInfo            block.Info
+	ExcludeFilters       []*filter.Filter
+	AutoProvisionFilters []*filter.Filter
+}
+
+type deviceWithAutoProvision struct {
+	bd              *diskv1.BlockDevice
+	AutoProvisioned bool
+}
+
+func NewScanner(
+	nodeName, namespace string,
+	bds ctldiskv1.BlockDeviceController,
+	block block.Info,
+	excludeFilters, autoProvisionFilters []*filter.Filter,
+) *Scanner {
+	return &Scanner{
+		NodeName:             nodeName,
+		Namespace:            namespace,
+		Blockdevices:         bds,
+		BlockInfo:            block,
+		ExcludeFilters:       excludeFilters,
+		AutoProvisionFilters: autoProvisionFilters,
+	}
+}
+
+func (s *Scanner) Start(ctx context.Context, rescanInterval time.Duration) error {
+	if err := s.scanBlockDevicesOnNode(); err != nil {
+		return err
+	}
+	// Rescan devices on the node periodically.
+	interval := defaultRescanInterval
+	if rescanInterval > 0 {
+		interval = rescanInterval * time.Second
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := s.scanBlockDevicesOnNode(); err != nil {
+					logrus.Errorf("Failed to rescan block devices on node %s: %v", s.NodeName, err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (s *Scanner) collectAllDevices() []*deviceWithAutoProvision {
+	allDevices := make([]*deviceWithAutoProvision, 0)
+	// list all the block devices
+	for _, disk := range s.BlockInfo.GetDisks() {
+		// ignore block device by filters
+		if s.ApplyExcludeFiltersForDisk(disk) {
+			continue
+		}
+		logrus.Debugf("Found a disk block device /dev/%s", disk.Name)
+		bd := GetDiskBlockDevice(disk, s.NodeName, s.Namespace)
+		if bd.Name == "" {
+			logrus.Infof("Skip adding non-identifiable block device /dev/%s", disk.Name)
+			continue
+		}
+		autoProv := s.ApplyAutoProvisionFiltersForDisk(disk)
+		allDevices = append(allDevices, &deviceWithAutoProvision{bd: bd, AutoProvisioned: autoProv})
+
+		for _, part := range disk.Partitions {
+			// ignore block device by filters
+			if s.ApplyExcludeFiltersForPartition(part) {
+				continue
+			}
+			logrus.Debugf("Found a partition block device /dev/%s", part.Name)
+			bd := GetPartitionBlockDevice(part, s.NodeName, s.Namespace)
+			if bd.Name == "" {
+				logrus.Infof("Skip adding non-identifiable block device %s", bd.Spec.DevPath)
+				continue
+			}
+			allDevices = append(allDevices, &deviceWithAutoProvision{bd: bd, AutoProvisioned: false})
+		}
+	}
+	return allDevices
+}
+
+// scanBlockDevicesOnNode scans block devices on the node, and it will either create or update them.
+func (s *Scanner) scanBlockDevicesOnNode() error {
+	logrus.Debugf("Scan block devices of node: %s", s.NodeName)
+
+	// list all the block devices
+	allDevices := s.collectAllDevices()
+
+	oldBdList, err := s.Blockdevices.List(s.Namespace, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", corev1.LabelHostname, s.NodeName),
+	})
+	if err != nil {
+		return err
+	}
+
+	oldBds := convertBlockDeviceListToMap(oldBdList)
+	for _, device := range allDevices {
+		bd := device.bd
+		autoProvisioned := device.AutoProvisioned
+		if oldBd, ok := oldBds[bd.Name]; ok {
+			// Only enqueue if auto-provisioned changes to enabled.
+			if !oldBd.Spec.FileSystem.Provisioned && autoProvisioned {
+				logrus.Debugf("Enqueue block device %s for auto-provisioning", bd.Name)
+				s.Blockdevices.Enqueue(s.Namespace, bd.Name)
+			} else {
+				logrus.Debugf("Skip updating device %s", bd.Name)
+			}
+			// remove blockdevice from old device so we can delete missing devices afterward
+			delete(oldBds, bd.Name)
+		} else {
+			logrus.Debugf("Enqueue device %s for creation", bd.Name)
+			// persist newly detected block device
+			if _, err := s.SaveBlockDevice(bd, autoProvisioned); err != nil && !errors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+	}
+
+	// This oldBds are leftover after running SaveBlockDevice.
+	// Clean up all previous registered block devices.
+	for _, oldBd := range oldBds {
+		logrus.Debugf("Delete device %s", oldBd.Name)
+		if err := s.Blockdevices.Delete(oldBd.Namespace, oldBd.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func convertBlockDeviceListToMap(bdList *diskv1.BlockDeviceList) map[string]*diskv1.BlockDevice {
+	bdMap := make(map[string]*diskv1.BlockDevice, len(bdList.Items))
+	for _, bd := range bdList.Items {
+		bd := bd
+		bdMap[bd.Name] = &bd
+	}
+	return bdMap
+}
+
+// ApplyExcludeFiltersForPartition check the status of disk for every
+// registered exclude filters. If the disk meets one of the criteria, it
+// returns true.
+func (s *Scanner) ApplyExcludeFiltersForDisk(disk *block.Disk) bool {
+	for _, filter := range s.ExcludeFilters {
+		if filter.ApplyDiskFilter(disk) {
+			logrus.Debugf("block device /dev/%s ignored by %s", disk.Name, filter.Name)
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyExcludeFiltersForPartition check the status of partition for every
+// registered exclude filters. If the partition meets one of the criteria, it
+// returns true.
+func (s *Scanner) ApplyExcludeFiltersForPartition(part *block.Partition) bool {
+	for _, filter := range s.ExcludeFilters {
+		if filter.ApplyPartFilter(part) {
+			logrus.Debugf("block device /dev/%s ignored by %s", part.Name, filter.Name)
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyAutoProvisionFiltersForDisk check the status of disk for every
+// registered auto-provision filters. If the disk meets one of the criteria, it
+// returns true.
+func (s *Scanner) ApplyAutoProvisionFiltersForDisk(disk *block.Disk) bool {
+	for _, filter := range s.AutoProvisionFilters {
+		if filter.ApplyDiskFilter(disk) {
+			logrus.Debugf("block device /dev/%s is promoted to auto-provision by %s", disk.Name, filter.Name)
+			return true
+		}
+	}
+	return false
+}
+
+// SaveBlockDevice persists the blockedevice information.
+func (s *Scanner) SaveBlockDevice(bd *diskv1.BlockDevice, autoProvisioned bool) (*diskv1.BlockDevice, error) {
+	if autoProvisioned {
+		bd.Spec.FileSystem.ForceFormatted = true
+		bd.Spec.FileSystem.Provisioned = true
+		bd.Spec.FileSystem.MountPoint = fmt.Sprintf("/var/lib/harvester/extra-disks/%s", bd.Name)
+	}
+	logrus.Infof("Add new block device %s with device: %s", bd.Name, bd.Spec.DevPath)
+	return s.Blockdevices.Create(bd)
+}

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -4,13 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-
-	"github.com/sirupsen/logrus"
 )
 
 // MakeExt4DiskFormatting create ext4 filesystem formatting of the specified devPath
 func MakeExt4DiskFormatting(devPath string) error {
-	logrus.Infof("make ext4 format of the device %s", devPath)
 	cmd := exec.Command("mkfs.ext4", "-F", devPath)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -19,11 +19,10 @@ import (
 )
 
 type Udev struct {
-	namespace  string
-	nodeName   string
-	startOnce  sync.Once
-	scanner    *blockdevice.Scanner
-	controller *blockdevice.Controller
+	namespace string
+	nodeName  string
+	startOnce sync.Once
+	scanner   *blockdevice.Scanner
 }
 
 func NewUdev(opt *option.Option, scanner *blockdevice.Scanner) *Udev {


### PR DESCRIPTION
## What does this try to resolve?

Related issue: harvester/harvester#1718

The problem of the original issue is that during disk formatting in a `OnBlockDeviceChange` call, `ScanBlockDevicesOnNode` periodically updates info of all block device CRs. When the disk formatting is finished and then tries to update the CR, it might hit the resource conflict error because `ScanBlockDevicesOnNode` have just updated the resources. That's where the race condition occur.

The basic gist of this pull request is to ensure that **only `OnBlockDeviceChange` can update** existing blockdevices. `ScanBlockDevicesOnNode` and uevent action handler only handle **create** and **delete** block device CRs.

Other changes in this PR:

- Extract scanner to its own file (CodeFactor forces me to do that...)
- Remove unused `status.state`.
- Lower the level of some noisy loggings.

## Test Plan

> ⚠️ This is a heuristic test plan since real world race condition is hard to reproduce. If you find any better alternative, feel free to comment.
> 
> This test is better to perform under QEMU/libvirt environment.

1. Prepare more than 10 extra disks for you harvester node.
2. Build NDM and update the version of harvester-node-disk-manager to this PR
3. Swipe all data on extra disks.
4. Enable auto-provision on NDM by adding an environment variable of the daemonset controller
    ```yaml
          - name: NDM_AUTO_PROVISION_FILTER
            value: /dev/sd*
    ```
5. Eventually, all disks matching the pattern should be partitioned, formatted and mounted successfully.
6. Check the log with the command `kubectl logs -n harvester-system ds/harvester-node-disk-manager -f`. After all disk being mounted, there should be no logs emitted.
7. Navigate to longhorn dashboard to see if each disk is successfully added and scheduled.