### PR TITLE
Don't expose `blockdevice.spec.fileSystem.mountPoint` to user

### DIFF
--- a/manifests/crds/harvesterhci.io_blockdevices.yaml
+++ b/manifests/crds/harvesterhci.io_blockdevices.yaml
@@ -32,8 +32,8 @@ spec:
     - jsonPath: .spec.nodeName
       name: NodeName
       type: string
-    - jsonPath: .status.state
-      name: Status
+    - jsonPath: .status.provisionPhase
+      name: ProvisionPhase
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -66,8 +66,9 @@ spec:
                       overwrite the existing one
                     type: boolean
                   mountPoint:
-                    description: a string with the partition's mount point, or ""
-                      if no mount point was discovered
+                    description: 'DEPRECATED: no longer use and has no effect. a string
+                      with the partition''s mount point, or "" if no mount point was
+                      discovered'
                     type: string
                   provisioned:
                     description: a bool indicating whether the filesystem can be provisioned

--- a/pkg/apis/harvesterhci.io/v1beta1/types.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/types.go
@@ -19,7 +19,7 @@ var (
 // +kubebuilder:printcolumn:name="DevPath",type="string",JSONPath=`.spec.devPath`
 // +kubebuilder:printcolumn:name="MountPoint",type="string",JSONPath=`.status.deviceStatus.fileSystem.mountPoint`
 // +kubebuilder:printcolumn:name="NodeName",type="string",JSONPath=`.spec.nodeName`
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.state`
+// +kubebuilder:printcolumn:name="ProvisionPhase",type="string",JSONPath=`.status.provisionPhase`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 type BlockDevice struct {

--- a/pkg/apis/harvesterhci.io/v1beta1/types.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/types.go
@@ -59,6 +59,7 @@ type BlockDeviceStatus struct {
 }
 
 type FilesystemInfo struct {
+	// DEPRECATED: no longer use and has no effect.
 	// a string with the partition's mount point, or "" if no mount point was discovered
 	MountPoint string `json:"mountPoint"`
 

--- a/pkg/controller/blockdevice/blockdevice.go
+++ b/pkg/controller/blockdevice/blockdevice.go
@@ -60,11 +60,9 @@ func GetDiskBlockDevice(disk *block.Disk, nodeName, namespace string) *diskv1.Bl
 			},
 		},
 		Spec: diskv1.BlockDeviceSpec{
-			NodeName: nodeName,
-			DevPath:  util.GetFullDevPath(disk.Name),
-			FileSystem: &diskv1.FilesystemInfo{
-				MountPoint: fileSystemInfo.MountPoint,
-			},
+			NodeName:   nodeName,
+			DevPath:    util.GetFullDevPath(disk.Name),
+			FileSystem: &diskv1.FilesystemInfo{},
 		},
 		Status: status,
 	}
@@ -114,11 +112,9 @@ func GetPartitionBlockDevice(part *block.Partition, nodeName, namespace string) 
 			},
 		},
 		Spec: diskv1.BlockDeviceSpec{
-			NodeName: nodeName,
-			DevPath:  util.GetFullDevPath(part.Name),
-			FileSystem: &diskv1.FilesystemInfo{
-				MountPoint: part.FileSystemInfo.MountPoint,
-			},
+			NodeName:   nodeName,
+			DevPath:    util.GetFullDevPath(part.Name),
+			FileSystem: &diskv1.FilesystemInfo{},
 		},
 		Status: status,
 	}

--- a/pkg/controller/blockdevice/blockdevice.go
+++ b/pkg/controller/blockdevice/blockdevice.go
@@ -23,7 +23,7 @@ func GetDiskBlockDevice(disk *block.Disk, nodeName, namespace string) *diskv1.Bl
 		Type:       disk.FileSystemInfo.Type,
 		IsReadOnly: disk.FileSystemInfo.IsReadOnly,
 	}
-
+	devPath := util.GetFullDevPath(disk.Name)
 	status := diskv1.BlockDeviceStatus{
 		State:          diskv1.BlockDeviceActive,
 		ProvisionPhase: diskv1.ProvisionPhaseUnprovisioned,
@@ -47,6 +47,7 @@ func GetDiskBlockDevice(disk *block.Disk, nodeName, namespace string) *diskv1.Bl
 				NUMANodeID:        disk.NUMANodeID,
 				WWN:               disk.WWN,
 			},
+			DevPath:    devPath,
 			FileSystem: fileSystemInfo,
 		},
 	}
@@ -61,7 +62,7 @@ func GetDiskBlockDevice(disk *block.Disk, nodeName, namespace string) *diskv1.Bl
 		},
 		Spec: diskv1.BlockDeviceSpec{
 			NodeName:   nodeName,
-			DevPath:    util.GetFullDevPath(disk.Name),
+			DevPath:    devPath,
 			FileSystem: &diskv1.FilesystemInfo{},
 		},
 		Status: status,
@@ -81,6 +82,7 @@ func GetPartitionBlockDevice(part *block.Partition, nodeName, namespace string) 
 		MountPoint: part.FileSystemInfo.MountPoint,
 		IsReadOnly: part.FileSystemInfo.IsReadOnly,
 	}
+	devPath := util.GetFullDevPath(part.Name)
 	status := diskv1.BlockDeviceStatus{
 		State:          diskv1.BlockDeviceActive,
 		ProvisionPhase: diskv1.ProvisionPhaseUnprovisioned,
@@ -99,6 +101,7 @@ func GetPartitionBlockDevice(part *block.Partition, nodeName, namespace string) 
 				StorageController: part.StorageController.String(),
 			},
 			FileSystem:   fileSystemInfo,
+			DevPath:      devPath,
 			ParentDevice: util.GetFullDevPath(part.Disk.Name),
 		},
 	}
@@ -113,7 +116,7 @@ func GetPartitionBlockDevice(part *block.Partition, nodeName, namespace string) 
 		},
 		Spec: diskv1.BlockDeviceSpec{
 			NodeName:   nodeName,
-			DevPath:    util.GetFullDevPath(part.Name),
+			DevPath:    devPath,
 			FileSystem: &diskv1.FilesystemInfo{},
 		},
 		Status: status,

--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -210,7 +210,6 @@ func (s *Scanner) SaveBlockDevice(bd *diskv1.BlockDevice, autoProvisioned bool) 
 	if autoProvisioned {
 		bd.Spec.FileSystem.ForceFormatted = true
 		bd.Spec.FileSystem.Provisioned = true
-		bd.Spec.FileSystem.MountPoint = fmt.Sprintf("/var/lib/harvester/extra-disks/%s", bd.Name)
 	}
 	logrus.Infof("Add new block device %s with device: %s", bd.Name, bd.Spec.DevPath)
 	return s.Blockdevices.Create(bd)


### PR DESCRIPTION
## What does this try to solve

Related: harvester/harvester#1936

Don't expose `mountpoint` to user. This should be an implementation details.

Compatibility notice: If there is a previous non-empty mount point exists, node-disk-manager would continue using that value.

## Test plan

#### Case 1: provision and unprovision back-and-forth

1. Prepare a harvester cluster (single node is sufficient)
1. Prepare an extra disk and add it to the host via Harvester Dashboard.
1. Expect the disk
   - is mounted (check with CLI `lsblk`, `mount`, etc.), and 
   - volumes can be scheduled onto it. (check its existence in longhorn dashboard)
1. Remove the disk from the host via Harvester Dashboard
1. Expect the disk 
   - is unmounted (check with CLI `lsblk`, `mount`, etc.), and
   - volumes cannot be scheduled onto it. (check its existence in longhorn dashboard)
1. Provision it again and see if the disk become schedulable again.
1. Provision it again and see if the disk is removed again.

#### Case 2: provision then reboot

1. Prepare a harvester cluster (single node is sufficient)
1. Prepare an extra disk and add it to the host via Harvester Dashboard.
1. Expect the disk
   - is mounted (check with CLI `lsblk`, `mount`, etc.), and 
   - volumes can be scheduled onto it. (check its existence in longhorn dashboard)
1. Reboot the host and wait for the harvester cluster ready
1. Expect the disk
   - is mounted (check with CLI `lsblk`, `mount`, etc.), and 
   - volumes can be scheduled onto it. (check its existence in longhorn dashboard)
1. Remove the disk from the host via Harvester Dashboard
1. Reboot the host and wait for the harvester cluster ready
1. Expect the disk 
   - is unmounted (check with CLI `lsblk`, `mount`, etc.), and
   - volumes cannot be scheduled onto it. (check its existence in longhorn dashboard)

#### Case 3: compatible with non-empty mount point

See: https://github.com/harvester/node-disk-manager/pull/33#issuecomment-1062669133

