### PR TITLE
Support resolve real dev path from UUID and PTUUID

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -220,7 +220,16 @@ func (c *Controller) forceFormat(device *diskv1.BlockDevice, devPath string, fil
 
 	// make ext4 filesystem format of the partition disk
 	logrus.Debugf("make ext4 filesystem format of device %s", device.Name)
-	// Reuse UUID if possible to make the filesystem UUID more stable
+	// Reuse UUID if possible to make the filesystem UUID more stable.
+	//
+	// The reason filesystem UUID needs to be stable is that if a disk
+	// lacks WWN, NDM then needs a UUID to determine the unique identity
+	// of the blockdevice CR.
+	//
+	// We don't reuse WWN as UUID here because we assume that WWN is
+	// stable and permanent for a disk. Thefore, even if the underlying
+	// device gets formatted and the filesystem UUID changes, it still
+	// won't affect then unique identity of the blockdevice.
 	var uuid string
 	if !valueExists(device.Status.DeviceStatus.Details.WWN) {
 		uuid = device.Status.DeviceStatus.Details.UUID

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -7,8 +7,12 @@ import (
 )
 
 // MakeExt4DiskFormatting create ext4 filesystem formatting of the specified devPath
-func MakeExt4DiskFormatting(devPath string) error {
-	cmd := exec.Command("mkfs.ext4", "-F", devPath)
+func MakeExt4DiskFormatting(devPath, uuid string) error {
+	args := []string{"-F", devPath}
+	if uuid != "" {
+		args = append(args, "-U", uuid)
+	}
+	cmd := exec.Command("mkfs.ext4", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err := cmd.Run()


### PR DESCRIPTION
Related: harvester/harvester#1874


### What does it resolve?

Starting from #26, NDM resolves device links to actual block device files. However, it only takes WWN into consideration. Since the GUID of blockdevice CR depends on WWN, UUID, and PTUUID (in this fablback order), NDM also needs a fallback chain to resolve to actual block device files.

### Test plan

#### Plug-unplug disks

1. Prepare a harvester cluster (single node is sufficient)
2. Prepare two disks
    - Both without WWN
    - Format one of the disk
    - Partition the other disk
3. Plug-in both disks and expect two blockdevice CR to show up without errors
4. Unplug both disks and wait for 30s, expect two blockdevice CR to be removed.
5. Plug-in both disk again.
    - Expect both disks to show up without errors
    - Expect both disks to get the same `Name`s as the last time they plugged in.

#### Swapping disks

1. Prepare a harvester cluster (single node is sufficient)
2. Prepare two disks and format both of them.
3. Hotplug both disks and add them to the host via Harvester Dashboard
4. Shutdown the host.
5. Swap the address and slot of the two disks in order to make their devpath swapped
    - For libvirt environment, you can swap `<address>` and `<target>` in the XML of the disk.
6. Reboot the host
7. Navigate to the "Host" page, both disks should be **healthy** and **scheduled**. 

