### PR TITLE
Add `status.deviceStatus.devPath`

### DIFF
--- a/manifests/crds/harvesterhci.io_blockdevices.yaml
+++ b/manifests/crds/harvesterhci.io_blockdevices.yaml
@@ -213,6 +213,9 @@ spec:
                     - driveType
                     - storageController
                     type: object
+                  devPath:
+                    description: device path
+                    type: string
                   fileSystem:
                     properties:
                       LastFormattedAt:
@@ -245,6 +248,7 @@ spec:
                 required:
                 - capacity
                 - details
+                - devPath
                 - fileSystem
                 - partitioned
                 type: object

--- a/pkg/apis/harvesterhci.io/v1beta1/types.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/types.go
@@ -83,6 +83,9 @@ type DeviceStatus struct {
 	// a object describe the disk details
 	Details DeviceDetails `json:"details"`
 
+	// device path
+	DevPath string `json:"devPath"`
+
 	FileSystem *FilesystemStatus `json:"fileSystem"`
 }
 

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -415,6 +415,9 @@ func (c *Controller) updateDeviceStatus(device *diskv1.BlockDevice, devPath stri
 		newStatus.FileSystem.LastFormattedAt = lastFormatted
 	}
 
+	// Update device path
+	newStatus.DevPath = devPath
+
 	if !reflect.DeepEqual(oldStatus, newStatus) {
 		logrus.Infof("Update existing block device status %s", device.Name)
 		device.Status.DeviceStatus = newStatus


### PR DESCRIPTION
Related: https://github.com/harvester/harvester/issues/2149

Just adding a resolved device path to `status.deviceStatus.devPath` for client to display.