### PR TITLE
Update devpath if changed

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -114,6 +114,7 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 			diskv1.DeviceFormatting.SetStatusBool(deviceCpy, false)
 		}
 		if !reflect.DeepEqual(device, deviceCpy) {
+			logrus.Debugf("Update block device %s for new formatting state", device.Name)
 			return c.Blockdevices.Update(deviceCpy)
 		}
 		return device, err
@@ -128,6 +129,7 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 			diskv1.DeviceMounted.SetStatusBool(deviceCpy, false)
 		}
 		if !reflect.DeepEqual(device, deviceCpy) {
+			logrus.Debugf("Update block device %s for new mount state", device.Name)
 			return c.Blockdevices.Update(deviceCpy)
 		}
 		return device, err
@@ -154,6 +156,7 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 	}
 
 	if !reflect.DeepEqual(device, deviceCpy) {
+		logrus.Debugf("Update block device %s for new provision state", device.Name)
 		return c.Blockdevices.Update(deviceCpy)
 	}
 
@@ -162,7 +165,9 @@ func (c *Controller) OnBlockDeviceChange(key string, device *diskv1.BlockDevice)
 	if err := c.updateDeviceStatus(deviceCpy, devPath); err != nil {
 		return nil, err
 	}
+
 	if !reflect.DeepEqual(device, deviceCpy) {
+		logrus.Debugf("Update block device %s for new status", device.Name)
 		return c.Blockdevices.Update(deviceCpy)
 	}
 

--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -133,7 +133,7 @@ func (s *Scanner) scanBlockDevicesOnNode() error {
 				logrus.Debugf("Enqueue block device %s for auto-provisioning", bd.Name)
 				s.Blockdevices.Enqueue(s.Namespace, bd.Name)
 			} else if isDevPathChanged(oldBd, bd) {
-				logrus.Debugf("Enqueue block device %s for device patch change", bd.Name)
+				logrus.Debugf("Enqueue block device %s for device path change", bd.Name)
 				s.Blockdevices.Enqueue(s.Namespace, bd.Name)
 			} else {
 				logrus.Debugf("Skip updating device %s", bd.Name)


### PR DESCRIPTION
When reboot, device path might change but controller cannot detect
it during the reconciliation. We explicitly check and update the value
when scanner startup.

related: https://github.com/harvester/harvester/issues/2149#issuecomment-1110488173