### PR TITLE
Use channel as semaphore to control concurrent ops

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,6 +119,13 @@ func main() {
 			Usage:       "A string of comma-separated glob patterns that auto-provisions devices matching provided device path",
 			Destination: &opt.AutoProvisionFilter,
 		},
+		&cli.UintFlag{
+			Name:        "max-concurrent-ops",
+			EnvVars:     []string{"NDM_MAX_CONCURRENT_OPS"},
+			Usage:       "Specify the maximum concurrent count of disk operations, such as formatting",
+			DefaultText: "5",
+			Destination: &opt.MaxConcurrentOps,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -307,13 +307,17 @@ func (c *Controller) provisionDeviceToNode(device *diskv1.BlockDevice) error {
 		if _, err = c.Nodes.Update(nodeCpy); err != nil {
 			return err
 		}
+
+		if !diskv1.DiskAddedToNode.IsTrue(device) {
+			// Update if needed. If the info is alreay there, no need to update.
+			msg := fmt.Sprintf("Added disk %s to longhorn node `%s` as an additional disk", device.Name, node.Name)
+			device.Status.ProvisionPhase = diskv1.ProvisionPhaseProvisioned
+			diskv1.DiskAddedToNode.SetError(device, "", nil)
+			diskv1.DiskAddedToNode.SetStatusBool(device, true)
+			diskv1.DiskAddedToNode.Message(device, msg)
+		}
 	}
 
-	msg := fmt.Sprintf("Added disk %s to longhorn node `%s` as an additional disk", device.Name, node.Name)
-	device.Status.ProvisionPhase = diskv1.ProvisionPhaseProvisioned
-	diskv1.DiskAddedToNode.SetError(device, "", nil)
-	diskv1.DiskAddedToNode.SetStatusBool(device, true)
-	diskv1.DiskAddedToNode.Message(device, msg)
 	return nil
 }
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -15,4 +15,5 @@ type Option struct {
 	LabelFilter         string
 	AutoProvisionFilter string
 	RescanInterval      int64
+	MaxConcurrentOps    uint
 }


### PR DESCRIPTION
Use bounded channel to control the concurrent count of block device
formatting. The default case will be hit only when the channel is
full or empty

related: https://github.com/harvester/harvester/issues/1831

## Test plan

1. Add a bunch of disks to a node.
2. Specify the flag `--max-concurrent-ops` to a number you want to test for node-disk-manager. You may also specify `--debug` for the sake of convenience to validate the behaviour.
3. Simultaneously set all `blockdevices` resource under namespace `longhorn-system` with `spec.fileSystem.forceFormatted = true` and `spec.fileSystem.provisioned = true`
4. Observe that only specified count of formatting operations can execute at a time. You can check the presence of log message `Hit maximum concurrent count. Requeue device %s` to verify.
    For instance, you might see something like this from daemonset harvester-node-disk-manager under harvester-system namespace.

    ```log
    time="2022 ... msg="make ext4 filesystem format of device 2521010654ca95f70d0bbfe675ffc7f0"
    time="2022 ... msg="make ext4 filesystem format of device 2d834e49e74c5e4a0cef37305dc68066"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device 42c7ef043dcd94204bce3097df97b90b"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device 69e979cdb0282c4ad8bd8c6c29687c3a"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device 6a5a18d2d1973bf55eab9089db581c21"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device 8f5d86905f0de6cc60a5294a281c429d"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device 992721a527bbd2b6d74f1591b73bc963"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device a327546473c0875ddafa70764ea8525e"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device a8dbb54a80dcf8883a028b1f22f60bbb"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device b195be8a2ef0c7134a420be5ded84d78"
    time="2022 ... msg="Hit maximum concurrent count. Requeue device b6c4ac0a1ad3434b9ca437b23215e75b"
    ```
