### PR TITLE
scanner: should not add the same wwn device again

### DIFF
--- a/ci/scripts/upgrade_ndm.sh
+++ b/ci/scripts/upgrade_ndm.sh
@@ -60,7 +60,7 @@ sleep 10 # wait 10 seconds for ndm start to respwan pods
 
 wait_ndm_ready
 # check image
-pod_name=$(kubectl get pods -n harvester-system |grep ^harvester-node-disk-manager|head -n1 |awk '{print $1}')
+pod_name=$(kubectl get pods -n harvester-system |grep Running |grep ^harvester-node-disk-manager|head -n1 |awk '{print $1}')
 container_img=$(kubectl get pods ${pod_name} -n harvester-system -o yaml |yq -e .spec.containers[0].image |tr ":" \n)
 yaml_img=$(yq -e .image.repository ndm-override.yaml)
 if grep -q ${yaml_img} <<< ${container_img}; then

--- a/pkg/utils/virt.go
+++ b/pkg/utils/virt.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+)
+
+type Disk struct {
+	XMLName xml.Name `xml:"disk"`
+	Type    string   `xml:"type,attr"`
+	Device  string   `xml:"device,attr"`
+	Driver  Driver   `xml:"driver"`
+	Source  Source   `xml:"source"`
+	Target  Target   `xml:"target"`
+	WWN     string   `xml:"wwn"`
+}
+
+type Driver struct {
+	Name string `xml:"name,attr"`
+	Type string `xml:"type,attr"`
+}
+
+type Source struct {
+	File string `xml:"file,attr"`
+}
+
+type Target struct {
+	Dev string `xml:"dev,attr"`
+	Bus string `xml:"bus,attr"`
+}
+
+// DiskXMLReader can read the libvirt disk xml file and return a Disk struct
+func DiskXMLReader(filePath string) (Disk, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return Disk{}, fmt.Errorf("open file(%s) error: %v", filePath, err)
+	}
+
+	defer f.Close()
+
+	var disk Disk
+	err = xml.NewDecoder(f).Decode(&disk)
+	if err != nil {
+		return Disk{}, fmt.Errorf("decode XML Error: %v", err)
+	}
+
+	return disk, nil
+}
+
+// XMLWriter write XML to target file, make sure your xmlData should valid
+func XMLWriter(targetFilePath string, xmlData any) error {
+	// Create a new file for writing
+	targetFile, err := os.Create(targetFilePath)
+	if err != nil {
+		return fmt.Errorf("create file(%s) error: %v", targetFilePath, err)
+	}
+	defer targetFile.Close()
+
+	// Encode the disk data and write it to the output file
+	encoder := xml.NewEncoder(targetFile)
+	err = encoder.Encode(xmlData)
+	if err != nil {
+		return fmt.Errorf("encod XML Error: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Problem:**
Get multiple blockdevice with the same WWN

**Solution:**
To prevent data broken with mis-operation, we should prevent creating the blockdevice with the same WWN.

**Related Issue:**
https://github.com/harvester/harvester/issues/4494

**Test plan:**
1. Create scsi controller files
- controller.xml
```
    <controller type='scsi' model='virtio-scsi' index='0'/>
```
Then, use following command to add virtio-scsi controller
```
virsh attach-device --domain <VM name> --file <controller file name> --live
```


2. Prepare two disk XML files with the same wwn as below:
- node-0-sda.xml
```
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2'/>
      <source file='/tmp/node-0-sda.qcow2'/>
      <target dev='sda' bus='scsi'/>
      <wwn>0x5000c50017654321</wwn>
    </disk>
```

- node-0-sdb.xml
```
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2'/>
      <source file='/tmp/node-0-sdb.qcow2'/>
      <target dev='sdb' bus='scsi'/>
      <wwn>0x5000c50017654321</wwn>
    </disk>
```

3. Then try to add these two disks to the host.
You can use the following command to add disk manually.
```
virsh attach-device --domain <VM name> --file <disk xml file> --live
```

4. Check the blockdevices CR. It only has one blockdevice existing, and it should be the first added.

**TODO ITEM**
- [x] Improve controller
- [x] add integration
