### PR TITLE
drone: remove binary release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,27 +27,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-amd64.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
 - name: docker-publish-master
   image: plugins/docker
   settings:


### PR DESCRIPTION
We do not release binary after this PR.
Users can get it from the image.