### PR TITLE
process: do not enable profiler by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,9 +69,8 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:        "profile-listen-address",
-			Value:       "0.0.0.0:6060",
-			DefaultText: "0.0.0.0:6060",
-			Usage:       "Address to listen on for profiling",
+			Value:       "",
+			Usage:       "Address to listen on for profiling, e.g. `:6060`",
 			Destination: &opt.ProfilerAddress,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
**Problem:**
NDM created with the `hostNetwork: true`. This parameter will expose the whole port on this pod to the host.
So, we need to prevent listening to unnecessary ports on NDM pods.

**Solution:**
we can disable profiler by default. NDM does not use it generally.

**Related Issue:**
https://github.com/harvester/harvester/issues/4212

**Test plan:**
make sure the host does not listen :6060
```
harvester-node-0:~ # ss -tnal |grep 6060
LISTEN 0      4096               *:6060             *:*
```

