### PR TITLE
drone: use environment instead env

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -150,7 +150,7 @@ volumes:
 kind: pipeline
 name: manifest
 
-env:
+environment:
   IMAGE_NAME: "rancher/harvester-node-disk-manager"
 
 steps:


### PR DESCRIPTION
Fix https://drone-publish.rancher.io/harvester/node-disk-manager/108/3/2