### PR TITLE
uevent: should respawn the uevent monitor

### DIFF
--- a/ci/charts/ndm-override.yaml
+++ b/ci/charts/ndm-override.yaml
@@ -6,3 +6,6 @@ image:
 
 autoProvisionFilter: [/dev/sd*]
 debug: true
+
+# we only manually inject udev monitor error once, so we can test it in CI.
+injectUdevMonitorError: true

--- a/main.go
+++ b/main.go
@@ -133,6 +133,13 @@ func main() {
 			DefaultText: "5",
 			Destination: &opt.MaxConcurrentOps,
 		},
+		&cli.BoolFlag{
+			Name:        "inject-udev-monitor-error",
+			EnvVars:     []string{"NDM_INJECT_UDEV_MONITOR_ERROR"},
+			Usage:       "Inject error when monitoring udev events",
+			Value:       false,
+			Destination: &opt.InjectUdevMonitorError,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -171,8 +178,8 @@ func initLogs(opt *option.Option) {
 	logrus.SetOutput(os.Stdout)
 	logrus.Infof("Node Disk Manager %s is starting", version.FriendlyVersion())
 	logrus.Infof("Notable parameters are following:")
-	logrus.Infof("Namespace: %s, ConcurrentOps: %d, RescanInterval: %d",
-		opt.Namespace, opt.MaxConcurrentOps, opt.RescanInterval)
+	logrus.Infof("Namespace: %s, ConcurrentOps: %d, RescanInterval: %d, InjectUdevMonitorError: %v",
+		opt.Namespace, opt.MaxConcurrentOps, opt.RescanInterval, opt.InjectUdevMonitorError)
 	if opt.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -6,14 +6,15 @@ type Option struct {
 	NodeName    string
 	Threadiness int
 
-	Debug               bool
-	Trace               bool
-	LogFormat           string
-	ProfilerAddress     string
-	VendorFilter        string
-	PathFilter          string
-	LabelFilter         string
-	AutoProvisionFilter string
-	RescanInterval      int64
-	MaxConcurrentOps    uint
+	Debug                  bool
+	Trace                  bool
+	LogFormat              string
+	ProfilerAddress        string
+	VendorFilter           string
+	PathFilter             string
+	LabelFilter            string
+	AutoProvisionFilter    string
+	RescanInterval         int64
+	MaxConcurrentOps       uint
+	InjectUdevMonitorError bool
 }


### PR DESCRIPTION
**Problem:**
The udev monitor will not work with any errors.

**Solution:**
We monitor the error and try to respawn it.

**Related Issue:**
https://github.com/harvester/harvester/issues/4925

**Test plan:**
Because the original error is hard to reproduce, I added another inject error here.

1. set the parameter `inject-udev-monitor-error` as true.
2. try to add a disk and provision it should work

