### PR TITLE
Remove rescan-interval CLI option and env var

### DIFF
--- a/deploy/charts/harvester-node-disk-manager/templates/daemonset.yaml
+++ b/deploy/charts/harvester-node-disk-manager/templates/daemonset.yaml
@@ -50,10 +50,6 @@ spec:
         - name: NDM_AUTO_PROVISION_FILTER
           value: {{ . | join "," | quote }}
         {{- end }}
-        {{- with .Values.rescanInterval }}
-        - name: NDM_RESCAN_INTERVAL
-          value: {{ . | quote }}
-        {{- end }}
         {{- with .Values.maxConcurrentOps }}
         - name: NDM_MAX_CONCURRENT_OPS
           value: {{ . | quote }}

--- a/deploy/charts/harvester-node-disk-manager/values.yaml
+++ b/deploy/charts/harvester-node-disk-manager/values.yaml
@@ -67,9 +67,6 @@ autoProvisionFilter: []
   # - /dev/sda?
   # - /dev/nvme0n1p1
 
-# Specify the interval of device rescanning of the node (in seconds)
-rescanInterval:
-
 # Sepcify how many concurrent ops we could execute at the same time
 maxConcurrentOps:
 

--- a/main.go
+++ b/main.go
@@ -113,12 +113,6 @@ func main() {
 			Usage:       "A string of comma-separated glob patterns that you want to exclude for block device filesystem label filter",
 			Destination: &opt.LabelFilter,
 		},
-		&cli.Int64Flag{
-			Name:        "rescan-interval",
-			EnvVars:     []string{"NDM_RESCAN_INTERVAL"},
-			Usage:       "Specify the interval of device rescanning of the node (in seconds)",
-			Destination: &opt.RescanInterval,
-		},
 		&cli.StringFlag{
 			Name:        "auto-provision-filter",
 			EnvVars:     []string{"NDM_AUTO_PROVISION_FILTER"},
@@ -178,8 +172,8 @@ func initLogs(opt *option.Option) {
 	logrus.SetOutput(os.Stdout)
 	logrus.Infof("Node Disk Manager %s is starting", version.FriendlyVersion())
 	logrus.Infof("Notable parameters are following:")
-	logrus.Infof("Namespace: %s, ConcurrentOps: %d, RescanInterval: %d, InjectUdevMonitorError: %v",
-		opt.Namespace, opt.MaxConcurrentOps, opt.RescanInterval, opt.InjectUdevMonitorError)
+	logrus.Infof("Namespace: %s, ConcurrentOps: %d, InjectUdevMonitorError: %v",
+		opt.Namespace, opt.MaxConcurrentOps, opt.InjectUdevMonitorError)
 	if opt.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -14,7 +14,6 @@ type Option struct {
 	PathFilter             string
 	LabelFilter            string
 	AutoProvisionFilter    string
-	RescanInterval         int64
 	MaxConcurrentOps       uint
 	InjectUdevMonitorError bool
 }


### PR DESCRIPTION
**Problem:**
Commit 7d5395f21c1167d2ad4bbe571d0e720e2ea61556 removed scanner polling, but the CLI option, environment variable and chart value remained.

**Solution:**
This PR

**Related Issue:**
N/A

**Test plan:**
N/A

