### PR TITLE
udev: refactor ActionHandler to get BD name on remove

### DIFF
--- a/pkg/block/util.go
+++ b/pkg/block/util.go
@@ -74,7 +74,7 @@ func lsblk(devPath, output string) (string, error) {
 	}
 	out, err := exec.Command(LSBLKCMD, args[0:]...).Output() // #nosec G204
 	if err != nil {
-		return "", fmt.Errorf("failed to execute `%s`: %s", strings.Join(args, " "), err.Error())
+		return "", fmt.Errorf("failed to execute `%s %s`: %s", LSBLKCMD, strings.Join(args, " "), err.Error())
 	}
 
 	return strings.TrimSuffix(string(out), "\n"), nil

--- a/pkg/udev/device.go
+++ b/pkg/udev/device.go
@@ -25,6 +25,7 @@ const (
 	UdevPartTableType = "ID_PART_TABLE_TYPE"
 	UdevPartTableUUID = "ID_PART_TABLE_UUID"
 	UdevSerialNumber  = "ID_SERIAL"
+	UdevSerialShort   = "ID_SERIAL_SHORT"
 	UdevType          = "ID_TYPE"
 	UdevVendor        = "ID_VENDOR"
 	UdevWWN           = "ID_WWN"
@@ -36,7 +37,7 @@ func InitUdevDevice(udev map[string]string) Device {
 	return udev
 }
 
-func (device Device) updateDiskFromUdev(disk *block.Disk) {
+func (device Device) UpdateDiskFromUdev(disk *block.Disk) {
 	if len(device[UdevFsUUID]) > 0 {
 		disk.UUID = device[UdevFsUUID]
 	}
@@ -49,7 +50,11 @@ func (device Device) updateDiskFromUdev(disk *block.Disk) {
 	if len(UdevVendor) > 0 {
 		disk.Vendor = device[UdevVendor]
 	}
-	if len(device[UdevSerialNumber]) > 0 {
+	// Match the logic from block.diskSerialNumber() to ensure
+	// we get the correct serial number!
+	if len(device[UdevSerialShort]) > 0 {
+		disk.SerialNumber = device[UdevSerialShort]
+	} else if len(device[UdevSerialNumber]) > 0 {
 		disk.SerialNumber = device[UdevSerialNumber]
 	}
 	if len(device[UdevWWN]) > 0 {


### PR DESCRIPTION
**Problem:**
When a device is removed, we're unable to determine the BD name (i.e. the name of the blockdevice CR) for logging purposes, because we're trying to figure it out based on device information in `/sys/class/block/...` and `/var/run/udev/data/...` but that isn't present anymore, because the device is gone.

**Solution:**
Use the data in the udev event instead for remove events. This change (IMO) simplifies `ActionHandler` a bit. I've also taken the liberty of introducing structured logging in that function, and I've included an (unrelated) small fix to an error string in `util.lsblk()`.

Log messages before this PR, when attaching/detaching a device (note the error messages and missing BD name on detach):

```
time="2024-07-16T12:21:36Z" level=info msg="Wake up scanner with add operation with blockdevice: b3270eab097d4515bac2d595665ac618"
time="2024-07-16T12:21:36Z" level=info msg="scanner waked up, do scan..."
time="2024-07-16T12:21:36Z" level=info msg="Detected the disk with block device /dev/sda, id(Name): b3270eab097d4515bac2d595665ac618 on node harvester-node-0"
time="2024-07-16T12:21:36Z" level=info msg="  - wwn: 0x1234567890123456"
time="2024-07-16T12:21:36Z" level=info msg="  - vendor: QEMU"
time="2024-07-16T12:21:36Z" level=info msg="  - model: QEMU_HARDDISK"
time="2024-07-16T12:21:36Z" level=info msg="  - SerialNumber: 1234567890123456"
time="2024-07-16T12:21:36Z" level=info msg="Create new device b3270eab097d4515bac2d595665ac618 with wwn: 0x1234567890123456"
time="2024-07-16T12:21:36Z" level=info msg="Add new block device b3270eab097d4515bac2d595665ac618 with device: /dev/sda"
time="2024-07-16T12:21:36Z" level=info msg="Waiting new event to trigger..."

[...]

WARNING: failed to read int from file: open /sys/block/sda/queue/rotational: no such file or directory
time="2024-07-16T12:21:55Z" level=info msg="Wake up scanner with remove operation with blockdevice: "
time="2024-07-16T12:21:55Z" level=info msg="scanner waked up, do scan..."
WARNING: failed to read disk partitions: open /sys/block/sda: no such file or directory
time="2024-07-16T12:21:55Z" level=info msg="Waiting new event to trigger..."
```

Log messages after this PR, when attaching/detaching a device:

```
time="2024-07-17T02:16:02Z" level=info msg="udev action triggering scanner wake" device=/dev/sda kind=BlockDevice name=b3270eab097d4515bac2d595665ac618 namespace=longhorn-system udevAction=add
time="2024-07-17T02:16:02Z" level=info msg="scanner waked up, do scan..."
time="2024-07-17T02:16:02Z" level=info msg="Detected the disk with block device /dev/sda, id(Name): b3270eab097d4515bac2d595665ac618 on node harvester-node-0"
time="2024-07-17T02:16:02Z" level=info msg="  - wwn: 0x1234567890123456"
time="2024-07-17T02:16:02Z" level=info msg="  - vendor: QEMU"
time="2024-07-17T02:16:02Z" level=info msg="  - model: QEMU_HARDDISK"
time="2024-07-17T02:16:02Z" level=info msg="  - SerialNumber: 1234567890123456"
time="2024-07-17T02:16:02Z" level=info msg="Waiting new event to trigger..."

[...]

time="2024-07-17T02:16:32Z" level=info msg="udev action triggering scanner wake" device=/dev/sda kind=BlockDevice name=b3270eab097d4515bac2d595665ac618 namespace=longhorn-system udevAction=remove
time="2024-07-17T02:16:32Z" level=info msg="scanner waked up, do scan..."
time="2024-07-17T02:16:32Z" level=info msg="Waiting new event to trigger..."
```

**Related Issue:**
N/A (I found these issues while working on https://github.com/harvester/harvester/issues/5059, but this PR is just a wee bit of cleanup)

**Test plan:**
N/A (no functional changes)