### PR TITLE
common: bump golang 1.22.7 and bci image 15.6

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -41,18 +41,19 @@ jobs:
       - name: "Local Deployment (Harvester+Longhorn+Node-Disk-Manager) for testing"
         id: vm_deploy
         run: |
-          rm -rf ndm-vagrant-rancherd
-          git clone https://github.com/harvester/vagrant-rancherd ndm-vagrant-rancherd
-          pushd ndm-vagrant-rancherd
-          ./new_cluster.sh
-          yq e -i ".longhorn_version = \"1.5.3\"" settings.yaml
+          rm -rf ndm-vagrant-k3s
+          git clone https://github.com/bk201/vagrant-k3s ndm-vagrant-k3s
+          pushd ndm-vagrant-k3s
+          yq e -i ".cluster_size = 1" settings.yaml
+          ./new-cluster.sh
+          yq e -i ".longhorn_version = \"1.7.1\"" settings.yaml
           ./scripts/deploy_longhorn.sh
           cp ../ci/scripts/deploy_ndm.sh ./deploy_ndm.sh
           ./deploy_ndm.sh
           popd
       - name: "Add disk"
         run: |
-          pushd ndm-vagrant-rancherd
+          pushd ndm-vagrant-k3s
           ./scripts/attach-disk.sh node1
           sleep 30
           popd
@@ -63,14 +64,14 @@ jobs:
           cat ci/charts/ndm-override.yaml 
       - name: "Upgrade NDM"
         run: |
-          pushd ndm-vagrant-rancherd
+          pushd ndm-vagrant-k3s
           cp ../ci/scripts/upgrade_ndm.sh ./upgrade_ndm.sh
           ./upgrade_ndm.sh
           popd
       - name: "Run Basic Test"
         id: basic-test
         run: |
-          pushd ndm-vagrant-rancherd
+          pushd ndm-vagrant-k3s
           vagrant ssh-config node1 > ../ssh-config
           cp kubeconfig ../kubeconfig
           popd
@@ -83,6 +84,6 @@ jobs:
       - name: "Tear Down / Cleanup"
         if: steps.vm_deploy.conclusion == 'success'
         run: |
-          pushd ndm-vagrant-rancherd
+          pushd ndm-vagrant-k3s
           vagrant destroy -f --parallel
           popd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/node-disk-manager
 
-go 1.22.5
+go 1.22.7
 
 replace (
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 # util-linux-systemd -> for `lsblk` command
 # e2fsprogs -> for `mkfs.ext4` command

--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -210,7 +210,7 @@ func (c *Controller) finalizeBlockDevice(oldBd, newBd *diskv1.BlockDevice, devPa
 }
 
 func (c *Controller) generateProvisioner(device *diskv1.BlockDevice) (provisioner.Provisioner, error) {
-	if device.Spec.Provisioner == nil && device.Status.ProvisionPhase != diskv1.ProvisionPhaseProvisioned {
+	if device.Spec.Provisioner == nil && !device.Spec.FileSystem.Provisioned && device.Status.ProvisionPhase != diskv1.ProvisionPhaseProvisioned {
 		return nil, nil
 	}
 	logrus.Infof("Generate provisioner from device %s, content: %v", device.Name, device.Spec.Provisioner)

--- a/tests/integration/test_1_disk_hotplug_test.go
+++ b/tests/integration/test_1_disk_hotplug_test.go
@@ -30,11 +30,11 @@ import (
  *
  * NOTE: The default qcow2 and xml location (created by initial operation) is `/tmp/hotplug_disks/`.
  *       File names are `node1-sda.qcow2` and `node1-sda.xml`.
- *       The target node name is `ndm-vagrant-rancherd_node1`.
+ *       The target node name is `ndm-vagrant-k3s_node1`.
  */
 
 const (
-	hotplugTargetNodeName  = "ndm-vagrant-rancherd_node1"
+	hotplugTargetNodeName  = "ndm-vagrant-k3s_node1"
 	hotplugDiskXMLFileName = "/tmp/hotplug_disks/node1-sda.xml"
 	hotplugTargetDiskName  = "sda"
 )


### PR DESCRIPTION
**Problem:**
bump golang 1.22.7 and bci-image 15.6

**Solution:**
bump golang 1.22.7 and bci-image 15.6

**Related Issue:**
https://github.com/harvester/harvester/issues/6568

**Test plan:**

