### PR TITLE
controller/scanner: should consider the wwn of the added blockdevice

### DIFF
--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -205,6 +205,8 @@ func (s *Scanner) scanBlockDevicesOnNode() error {
 				logrus.Warnf("Skip adding duplicated WWN device %s, device path: %s", bd.Status.DeviceStatus.Details.WWN, bd.Spec.DevPath)
 				continue
 			}
+			existingWWNs = append(existingWWNs, bd.Status.DeviceStatus.Details.WWN)
+			logrus.Debugf("The current WWNs are: %v", existingWWNs)
 			logrus.Infof("Create new device %s with wwn: %s", bd.Name, bd.Status.DeviceStatus.Details.WWN)
 			if _, err := s.SaveBlockDevice(bd, autoProvisioned); err != nil && !errors.IsAlreadyExists(err) {
 				return err


### PR DESCRIPTION
    - We should also consider the wwn of the added blockdevice in
      the same round.

**Problem:**
It would not work well if two duplicate WWN devices wanted to join simultaneously.

**Solution:**
Should consider the WWNs even if in the same round

**Related Issue:**
https://github.com/harvester/harvester/issues/6604

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

