### PR TITLE
controller: consider the new provision field

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -319,6 +319,7 @@ func (c *Controller) updateDeviceStatus(device *diskv1.BlockDevice, devPath stri
 		logrus.Infof("Auto provisioning block device %s", device.Name)
 		device.Spec.FileSystem.ForceFormatted = true
 		device.Spec.FileSystem.Provisioned = true
+		device.Spec.Provision = true
 	}
 	return nil
 }

--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -284,6 +284,7 @@ func (s *Scanner) SaveBlockDevice(bd *diskv1.BlockDevice, autoProvisioned bool) 
 			if autoProvisioned {
 				bd.Spec.FileSystem.ForceFormatted = true
 				bd.Spec.FileSystem.Provisioned = true
+				bd.Spec.Provision = true
 			}
 			logrus.Infof("Add new block device %s with device: %s", bd.Name, bd.Spec.DevPath)
 			return s.Blockdevices.Create(bd)
@@ -301,7 +302,7 @@ func (s *Scanner) SaveBlockDevice(bd *diskv1.BlockDevice, autoProvisioned bool) 
 // - disk hasn't yet been force formatted
 // - disk matches auto-provisioned patterns
 func (s *Scanner) NeedsAutoProvision(oldBd *diskv1.BlockDevice, autoProvisionPatternMatches bool) bool {
-	return !oldBd.Spec.FileSystem.Provisioned && autoProvisionPatternMatches && oldBd.Status.DeviceStatus.FileSystem.LastFormattedAt == nil
+	return !oldBd.Spec.FileSystem.Provisioned && !oldBd.Spec.Provision && autoProvisionPatternMatches && oldBd.Status.DeviceStatus.FileSystem.LastFormattedAt == nil
 }
 
 // isDevPathChanged returns true if the device path has changed.

--- a/pkg/provisioner/longhornv1.go
+++ b/pkg/provisioner/longhornv1.go
@@ -439,8 +439,9 @@ func needUpdateMountPoint(bd *diskv1.BlockDevice, filesystem *block.FileSystemIn
 		return NeedMountUpdateNoOp
 	}
 
-	logrus.Debugf("Checking mount operation with FS.Provisioned %v, FS.Mountpoint %s", bd.Spec.FileSystem.Provisioned, filesystem.MountPoint)
-	if bd.Spec.FileSystem.Provisioned {
+	provisioned := bd.Spec.FileSystem.Provisioned || bd.Spec.Provision
+	logrus.Debugf("Checking mount operation with FS.Provisioned %v, FS.Mountpoint %s", provisioned, filesystem.MountPoint)
+	if provisioned {
 		if filesystem.MountPoint == "" {
 			return NeedMountUpdateMount
 		}


### PR DESCRIPTION
**Problem:**
Missing mountpoint when provisioning the longhorn V1

**Solution:**
We need to improve the handling with the new provision field `Spec.Provision`.
Walk through the whole `Spec.Filesystem.Provisioned` logic and improve them.

**Related Issue:**
None

**Test plan:**
Make sure the longhornV1 can works as usual only with the new provision field `Spec.Provision`.

