### PR TITLE
Fix two issues encountered when testing LHv2 provisioning

### DIFF
--- a/pkg/provisioner/longhornv2.go
+++ b/pkg/provisioner/longhornv2.go
@@ -135,11 +135,13 @@ func (p *LonghornV2Provisioner) Update() (isRequeueNeeded bool, err error) {
 
 	// Sync disk driver
 	if targetDisk, found := p.nodeObj.Spec.Disks[p.device.Name]; found {
-		nodeCpy := p.nodeObj.DeepCopy()
+		nodeObjCpy := p.nodeObj.DeepCopy()
 		targetDisk.DiskDriver = p.device.Spec.Provisioner.Longhorn.DiskDriver
-		nodeCpy.Spec.Disks[p.device.Name] = targetDisk
-		if _, err = p.nodesClient.Update(nodeCpy); err != nil {
-			isRequeueNeeded = true
+		nodeObjCpy.Spec.Disks[p.device.Name] = targetDisk
+		if !reflect.DeepEqual(p.nodeObj, nodeObjCpy) {
+			if _, err = p.nodesClient.Update(nodeObjCpy); err != nil {
+				isRequeueNeeded = true
+			}
 		}
 	}
 	return


### PR DESCRIPTION
**Problem:**
1. Disks added for use by LHv2 are added successfully, but their status remains stuck with an error "spec and status of disks on node $NAME are being syncing and please retry later."
2. Active LHv2 volumes attached to VMs appear as `/dev/dm-*` and `/dev/nvme*` devices on the host. NDM sees these and thinks they're real disks, and then creates new BD CRs from those devices.

**Solution:**
1. Add a call to `reflect.DeepEqual()` to avoid unnecessary updates and resultant weird state.
2. Abuse the existing vendor filter to pick up SPDK devices, and explicitly exclude `/dev/dm-` devices in `ApplyExcludeFiltersForDisk()`.

Note: I intend to handle this more cleanly later as part of https://github.com/harvester/harvester/issues/5059

**Related Issue:**
https://github.com/harvester/harvester/issues/5274

**Test plan:**
N/A

