### PR TITLE
scanner: correct the autoProvision mechanism

### DIFF
--- a/pkg/controller/blockdevice/controller.go
+++ b/pkg/controller/blockdevice/controller.go
@@ -316,7 +316,6 @@ func (c *Controller) updateDeviceStatus(device *diskv1.BlockDevice, devPath stri
 		logrus.Infof("Auto provisioning block device %s", device.Name)
 		device.Spec.FileSystem.ForceFormatted = true
 		device.Spec.FileSystem.Provisioned = true
-		device.Spec.Provision = true
 	}
 	return nil
 }

--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -292,7 +292,6 @@ func (s *Scanner) SaveBlockDevice(bd *diskv1.BlockDevice, autoProvisioned bool) 
 			if autoProvisioned {
 				bd.Spec.FileSystem.ForceFormatted = true
 				bd.Spec.FileSystem.Provisioned = true
-				bd.Spec.Provision = true
 			}
 			logrus.Infof("Add new block device %s with device: %s", bd.Name, bd.Spec.DevPath)
 			return s.Blockdevices.Create(bd)


### PR DESCRIPTION
    - we should not set both `Spec.Filesystem.Provisioned` and
      `Spec.Provision` or the remove operation would be blocked if
      we only change one of these to false.

    This is a side-effect that comes from 1877a4ef1743e4bb01b81179aacfe5b32da059ed.
    For now, we will remove one of these two fields to ensure the delete operation
    work. We still need mutator to help convert these two fields.

**Problem:**
The removal operation would be blocked if we only changed one of these to false.

**Solution:**
For now, we will remove one of these two fields to ensure the delete operation work.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

