### PR TITLE
provisioner: ensure the device is ready before adding into volume group

### DIFF
--- a/pkg/provisioner/lvm.go
+++ b/pkg/provisioner/lvm.go
@@ -40,8 +40,11 @@ func (l *LVMProvisioner) GetProvisionerName() string {
 	return l.name
 }
 
-func (l *LVMProvisioner) Format(string) (bool, bool, error) {
-	// LVM provisioner does not need format
+// Format operation on the LVM use to ensure the device is clean and ready to be used by LVM.
+func (l *LVMProvisioner) Format(devPath string) (isFormatComplete, isRequeueNeeded bool, err error) {
+	if _, err := utils.NewExecutor().Execute("wipefs", []string{"-a", devPath}); err != nil {
+		return false, false, err
+	}
 	return true, false, nil
 }
 


### PR DESCRIPTION
    - The filesystem metadata would break the pvcreate

**Problem:**
The filesystem metadata would break the pvcreate

**Solution:**
make sure the device is clean

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

