### PR TITLE
Make the build consistent across archs for Go to correctly report the package path inside the binary

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -14,6 +14,6 @@ LINKFLAGS="-X github.com/harvester/node-disk-manager/pkg/version.Version=$VERSIO
            -X github.com/harvester/node-disk-manager/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/node-disk-manager-"$arch" cmd/node-disk-manager/main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/node-disk-manager-webhook-"$arch" cmd/node-disk-manager-webhook/main.go
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/node-disk-manager-"$arch" ./cmd/node-disk-manager
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/node-disk-manager-webhook-"$arch" ./cmd/node-disk-manager-webhook
 done


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The build process is passing directly the `main.go` file for the build. According to Go's spec, this results in Go not properly identifying the package and module path and then marking the compiled binary as `command-line-arguments`.

Before:

```
> go version -m main
main: go1.22.9
	path	command-line-arguments
```

Now:

```
> go version -m node-disk-manager 
node-disk-manager: go1.22.9
	path	github.com/harvester/node-disk-manager/cmd/node-disk-manager
	mod	github.com/harvester/node-disk-manager	(devel)	
```

Although this is a minor thing and that doesn't affect the binary itself, it actually blocks security scanners, for example Trivy, from correctly matching the binary (and its path/module origin) with a VEX entry.

This was identified internally when a false-positive vulnerability that was supposed to be suppressed was still being reported in the scanning reports.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Only pass the directory that contains the Go file to build, not the file itself.

**Related Issue:**
N/A

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
See above.