### PR TITLE
ci: tune Renovate base branches [skip ci]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": [
         "github>harvester/renovate:renovate-default"
-    ]
+    ],
+    "baseBranches": ["master", "/^v.*/"]
 }


### PR DESCRIPTION
The [default configuration ](https://github.com/harvester/renovate/blob/bf6a43711f19c73e2c96e94132eeac8b630af1c8/renovate-default.json#L6C5-L10)doesn't work for this repo.