### PR TITLE
ci: use ubuntu 24.04 as 20.04 was unsupported

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
https://github.com/actions/runner-images/issues/11101
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

