### PR TITLE
Fix go-mod warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/harvester/node-disk-manager
 go 1.24.2
 
 replace (
+	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
+	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c
+	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20240919204204-3da2ae0cabd1
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e
 	k8s.io/api => k8s.io/api v0.32.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -772,6 +772,9 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
+# github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c
+# github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20240919204204-3da2ae0cabd1
 # gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e
 # k8s.io/api => k8s.io/api v0.32.6
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.6


### PR DESCRIPTION
Get rid of
```
go: github.com/openshift/api@v0.0.0: invalid version: unknown revision v0.0.0
go: github.com/openshift/client-go@v0.0.0: invalid version: unknown revision v0.0.0
go: github.com/rancher/rancher/pkg/apis@v0.0.0: invalid version: unknown revision pkg/apis/v0.0.0
```
The module versions were taken from the Harvester v1.5.1 which adds them as indirect requirements to node-disk-manager.
```
$ go mod graph | grep github.com/openshift/api
github.com/harvester/harvester@v1.5.1 github.com/openshift/api@v0.0.0

$ go mod graph | grep github.com/openshift/client-go     
github.com/harvester/harvester@v1.5.1 github.com/openshift/client-go@v0.0.0

$ go mod graph | grep github.com/rancher/rancher/pkg/apis
github.com/harvester/harvester@v1.5.1 github.com/rancher/rancher/pkg/apis@v0.0.0
```