### PR TITLE
ci: use release event to avoid ci skip [ci skip]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release Build and Publish
 
 on:
-  push:
-    tags:
-    - v**
+  release:
+    types:
+    - published
 
 jobs:
   build-for-release:


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

If the tagged commit contains any CI-skip requests, the release workflow cannot be triggered.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use the `release` event instead of the `push` event. Ideally, both prereleases and releases can trigger the workflow no matter what forms of CI-skip requests are made in the commit message.

**Related Issue:**

harvester/harvester#9048

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

