### PR TITLE
Pin GH Actions to commit sha

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - golang
     steps:
       - name: "Clone and check"
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: "Run validations"
         run: |
           make validate
@@ -32,7 +32,7 @@ jobs:
       - golang
     steps:
       - name: "Clone and check"
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: "Build Integration Test Image and run Unit Tests"
         run: |
           BUILD_FOR_CI=true make
@@ -113,7 +113,7 @@ jobs:
       - golang
     steps:
       - name: "Clone and check"
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: "Build Integration Test Image and run Unit Tests"
         run: |
           BUILD_FOR_CI=true make

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,11 +22,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -37,7 +37,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -51,4 +51,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2

--- a/.github/workflows/factory.yaml
+++ b/.github/workflows/factory.yaml
@@ -25,25 +25,25 @@ jobs:
     steps:
     - name: Checkout code without refs
       if: ${{ inputs.refs == '' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Checkout code with refs
       if: ${{ inputs.refs != '' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ inputs.refs }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Run dapper
       run: make ci
 
     - name: Read some Secrets
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
       if: ${{ inputs.push == true }}
       with:
         secrets: |
@@ -51,14 +51,14 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       if: ${{ inputs.push == true }}
       with:
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}
 
     - name: Docker Build (Controller)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .
@@ -68,7 +68,7 @@ jobs:
         tags: ${{ env.repo }}/${{ env.controllerImageName }}:${{ inputs.tag }}
 
     - name: Docker Build (Webhook)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,13 +20,13 @@ jobs:
     # The FOSSA token is shared between all repos in Harvester's GH org. It can
     # be used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
       with:
         secrets: |
           secret/data/github/org/harvester/fossa/credentials token | FOSSA_API_KEY_PUSH_ONLY
 
     - name: FOSSA scan
-      uses: fossas/fossa-action@main
+      uses: fossas/fossa-action@c414b9ad82eaad041e47a7cf62a4f02411f427a0 # v1.8.0
       with:
         api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
         # Only runs the scan and do not provide/returns any results back to the

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download Rancher's VEX Hub report
         run: curl -fsSO https://raw.githubusercontent.com/rancher/vexhub/refs/heads/main/reports/rancher.openvex.json
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -30,6 +30,6 @@ jobs:
           TRIVY_SHOW_SUPPRESSED: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR is part of an org-wide effort to pin GHA action references to immutable commit SHAs. It contains results from the RST `pin-gha-to-sha.sh` script where any `uses:` references to tags or branches are replaced by immutable commit SHAs.

Related to https://github.com/harvester/harvester/issues/10279