### PR TITLE
fix: LHv2: don't use BDF paths when driver set to 'aio'

### DIFF
--- a/pkg/provisioner/longhornv2.go
+++ b/pkg/provisioner/longhornv2.go
@@ -172,9 +172,11 @@ func resolveLonghornV2DevPath(device *diskv1.BlockDevice) (string, error) {
 			device.Status.DeviceStatus.Details.DeviceType)
 	}
 	devPath := ""
-	if device.Status.DeviceStatus.Details.StorageController == string(diskv1.StorageControllerVirtio) ||
-		device.Status.DeviceStatus.Details.StorageController == string(diskv1.StorageControllerNVMe) {
-		// In both of these cases, we should (hopefully!) be able to extract BDF from BusPath
+	if (device.Status.DeviceStatus.Details.StorageController == string(diskv1.StorageControllerVirtio) ||
+		device.Status.DeviceStatus.Details.StorageController == string(diskv1.StorageControllerNVMe)) &&
+		device.Spec.Provisioner.Longhorn.DiskDriver != longhornv1.DiskDriverAio {
+		// In both of these cases, we should (hopefully!) be able to extract BDF from BusPath,
+		// but this can't be used with the "aio" disk driver (that needs a regular device path)
 		if strings.HasPrefix(device.Status.DeviceStatus.Details.BusPath, "pci-") {
 			devPath = strings.Split(device.Status.DeviceStatus.Details.BusPath, "-")[1]
 		}
@@ -187,7 +189,11 @@ func resolveLonghornV2DevPath(device *diskv1.BlockDevice) (string, error) {
 		}).Warn("Unable to extract BDF from BusPath, falling back to WWN")
 	}
 	if wwn := device.Status.DeviceStatus.Details.WWN; valueExists(wwn) {
-		devPath = "/dev/disk/by-id/wwn-" + wwn
+		if device.Status.DeviceStatus.Details.StorageController == string(diskv1.StorageControllerNVMe) {
+			devPath = "/dev/disk/by-id/nvme-" + wwn
+		} else {
+			devPath = "/dev/disk/by-id/wwn-" + wwn
+		}
 		_, err := os.Stat(devPath)
 		if err == nil {
 			return devPath, nil
@@ -195,9 +201,10 @@ func resolveLonghornV2DevPath(device *diskv1.BlockDevice) (string, error) {
 		logrus.WithFields(logrus.Fields{
 			"device": device.Name,
 			"wwn":    device.Status.DeviceStatus.Details.WWN,
-		}).Warn("/dev/disk/by-id/wwn-* path does not exist for device")
+		}).Warn("/dev/disk/by-id/* path does not exist for device")
 	}
 	if busPath := device.Status.DeviceStatus.Details.BusPath; valueExists(busPath) {
+		// This won't work for LHv2 devices util https://github.com/longhorn/longhorn/issues/13228 is fixed
 		devPath = "/dev/disk/by-path/" + busPath
 		_, err := os.Stat(devPath)
 		if err == nil {


### PR DESCRIPTION
**Problem:**
The Longhorn V2 aio bdev driver needs a regular device path to a disk (e.g. "/dev/whatever"), but currently NDM will always try to use BDF paths for NVMe or virtio devices even if the disk driver is set to aio. In this case, Longhorn just doesn't know what to do and can't add the disk.

**Solution:**
We can fix this by ensuring NDM doesn't try to resolve BDF paths if the disk driver is set to aio.

This commit also fixes `/dev/disk/by-id/` path generation for NVMe devices.

**Related Issue:**
https://github.com/harvester/harvester/issues/10666

**Test plan:**
- Start with a host with a direct attached NVMe device (e.g. `/dev/nvme0n1`) and LHv2 enabled.
- Add the NVMe using the Harvester GUI, and wait for it to be added to LH and be Ready and Schedulable. This is the normal case, and NDM will have automatically added it to LH using a BDF path. If you check the LH GUI, you should see Disk Type: Block, and Path as a string of numbers, e.g. "0000:00:10.0". You can also check Longhorn's node config, e.g.:
  ```
  # kubectl -n longhorn-system get node.longhorn.io/harvester-node-0 -o yaml 
  ...
  spec:
    disks:
      b705b00a-d807-44a3-b756-6e434e57b072:
        allowScheduling: true
        diskDriver: auto                <-- note: auto
        diskType: block                 <-- note: block
        evictionRequested: false
        path: "0000:00:10.0"            <-- note: BDF path
        storageReserved: 0
        tags: []
  ```

- Go back to the Harvester GUI and remove that disk from the host. Wait until everything settles down and the disk is really gone from LH (this should be pretty quick, but check the LH GUI to be sure).
- Edit that disk's BD resource to tell it to provision again, but set `diskDriver` to `aio`, e.g.:
  ```
  # kubectl -n longhorn-system get bd
  NAME                                   TYPE   DEVPATH        MOUNTPOINT   NODENAME           PROVISIONPHASE   AGE
  b705b00a-d807-44a3-b756-6e434e57b072   disk   /dev/nvme0n1                harvester-node-0   Unprovisioned    44m

  # kubectl -n longhorn-system edit bd/b705b00a-d807-44a3-b756-6e434e57b072
  ...
  spec:
    devPath: /dev/nvme0n1
    ...
    provision: true                 <-- set this to true (will initially be false)
    provisioner:
      longhorn:
        diskDriver: aio             <-- set this to aio (will initially be auto)
        engineVersion: LonghornV2
  ```
- Now, if you are running an older version of NDM _without_ this fix, the problem will be apparent: The disk will have been added to LH with the BDF path, but also with diskDriver set to `aio`, and the disk will be unschedulable:
  ```
  # kubectl -n longhorn-system get node.longhorn.io/harvester-node-0 -o yaml 
  ...
  spec:
    disks:
      b705b00a-d807-44a3-b756-6e434e57b072:
        allowScheduling: true
        diskDriver: aio                 <-- note: aio
        diskType: block                 <-- note: block
        evictionRequested: false
        path: "0000:00:10.0"            <-- note: BDF path
        storageReserved: 0
        tags: []
  ```
<img width="947" height="198" alt="image" src="https://github.com/user-attachments/assets/59ae56a0-66f1-4b29-b232-b6a679cbc918" />
<img width="895" height="246" alt="image" src="https://github.com/user-attachments/assets/0f301ed9-d740-4af3-bb9a-a963fbe8a3b7" />

- If you do the above test using a version of NDM _with_ this fix, the disk will be added using a `/dev/disk/by-id` path, and will run and schedule correctly:
  ```
  # kubectl -n longhorn-system get node.longhorn.io/harvester-node-0 -o yaml 
  ...
  spec:
    disks:
      b705b00a-d807-44a3-b756-6e434e57b072:
        allowScheduling: true
        diskDriver: aio                 <-- note: aio
        diskType: block                 <-- note: block
        evictionRequested: false
        path: /dev/disk/by-id/nvme-nvme.1b36-305f31323334-51454d55204e564d65204374726c-00000001  <-- note: big long path
        storageReserved: 0
        tags: []
  ```
<img width="831" height="194" alt="image" src="https://github.com/user-attachments/assets/3160e7f1-432e-4033-8b42-d9dab95ece75" />
<img width="892" height="292" alt="image" src="https://github.com/user-attachments/assets/048b7163-8cd8-43e8-b7c9-45e01971243b" />
