### PR TITLE
feat: implement mount watcher for Linux and integrate with Udev monitor

### DIFF
--- a/pkg/controller/blockdevice/scanner.go
+++ b/pkg/controller/blockdevice/scanner.go
@@ -406,6 +406,19 @@ func (s *Scanner) scanBlockDevicesOnNode(ctx context.Context) error {
 			}
 		}
 
+		// A device with a mount point is only tracked when it was provisioned by NDM
+		// (meaning Longhorn mounted it as part of the normal flow). If it is mounted
+		// but not yet provisioned, an external process mounted it and NDM should leave
+		// it alone. For unprovisioned existing BDs in that case, deactivateOrDeleteBlockDevices
+		// will clean up the stale CR.
+		if mp := newBd.Status.DeviceStatus.FileSystem.MountPoint; mp != "" {
+			if existingBd == nil || existingBd.Status.ProvisionPhase != diskv1.ProvisionPhaseProvisioned {
+				logrus.Infof("block device %s is mounted at %s but not provisioned by NDM, ignoring",
+					newBd.Status.DeviceStatus.DevPath, mp)
+				continue
+			}
+		}
+
 		if existingBd != nil {
 			// Pick up the name of the existing block device we found (not strictly necessary,
 			// but just in case we try to use newBd.name in handleExistingDev...)

--- a/pkg/udev/mount_watcher.go
+++ b/pkg/udev/mount_watcher.go
@@ -1,0 +1,76 @@
+//go:build linux
+
+package udev
+
+import (
+	"context"
+	"math"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/harvester/node-disk-manager/pkg/utils"
+)
+
+// NDM mounts the host's /proc at /host/proc (see daemonset.yaml), so we watch
+// /host/proc/1/mountinfo (host PID 1 = init) to observe the host mount namespace.
+// Using /proc/self/mountinfo would only reflect the container's own namespace.
+const procMountInfo = "/host/proc/1/mountinfo"
+
+// watchMounts monitors mount table changes by polling /proc/self/mountinfo for POLLERR.
+// The kernel raises POLLERR on this fd whenever any mount or umount occurs.
+func (u *Udev) watchMounts(ctx context.Context) {
+	logrus.Debugf("mount watcher: opening %s", procMountInfo)
+	fd, err := unix.Open(procMountInfo, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		logrus.Errorf("mount watcher: failed to open %s: %v", procMountInfo, err)
+		return
+	}
+	logrus.Debugf("mount watcher: opened fd=%d", fd)
+	defer func() {
+		logrus.Debugf("mount watcher: closing fd=%d", fd)
+		unix.Close(fd)
+	}()
+
+	if fd > math.MaxInt32 {
+		logrus.Errorf("mount watcher: fd %d out of int32 range", fd)
+		return
+	}
+	fdInt32 := int32(fd) //nolint:gosec // fd is guaranteed non-negative by Open and bounded by math.MaxInt32 check above
+
+	// POLLERR fires when the kernel marks /proc/self/mountinfo dirty (mount/umount)
+	fds := []unix.PollFd{{Fd: fdInt32, Events: unix.POLLERR}}
+
+	logrus.Infof("mount watcher: watching %s for mount table changes", procMountInfo)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logrus.Debug("mount watcher: context cancelled, exiting")
+			return
+		default:
+		}
+
+		logrus.Debugf("mount watcher: polling fd=%d for POLLERR, timeout=5s", fd)
+		n, err := unix.Poll(fds, 5*1000)
+		if err != nil {
+			if err == unix.EINTR {
+				logrus.Debug("mount watcher: poll interrupted by signal, retrying")
+				continue
+			}
+			logrus.Errorf("mount watcher: poll error: %v", err)
+			return
+		}
+		if n == 0 {
+			logrus.Debug("mount watcher: poll timeout, no mount changes")
+			continue
+		}
+
+		logrus.Debugf("mount watcher: POLLERR received (revents=0x%x), mount table changed", fds[0].Revents)
+		utils.CallerWithCondLock(u.scanner.Cond, func() any {
+			logrus.Info("mount watcher: mount change detected, waking scanner")
+			u.scanner.Cond.Signal()
+			return nil
+		})
+	}
+}

--- a/pkg/udev/mount_watcher.go
+++ b/pkg/udev/mount_watcher.go
@@ -4,6 +4,7 @@ package udev
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/sirupsen/logrus"
@@ -19,11 +20,12 @@ const procMountInfo = "/host/proc/1/mountinfo"
 
 // watchMounts monitors mount table changes by polling /proc/self/mountinfo for POLLERR.
 // The kernel raises POLLERR on this fd whenever any mount or umount occurs.
-func (u *Udev) watchMounts(ctx context.Context) {
+// On any unrecoverable error it sends to errChan so spawnMountWatcher can respawn it.
+func (u *Udev) watchMounts(ctx context.Context, errChan chan error) {
 	logrus.Debugf("mount watcher: opening %s", procMountInfo)
 	fd, err := unix.Open(procMountInfo, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
-		logrus.Errorf("mount watcher: failed to open %s: %v", procMountInfo, err)
+		errChan <- fmt.Errorf("failed to open %s: %w", procMountInfo, err)
 		return
 	}
 	logrus.Debugf("mount watcher: opened fd=%d", fd)
@@ -33,7 +35,7 @@ func (u *Udev) watchMounts(ctx context.Context) {
 	}()
 
 	if fd > math.MaxInt32 {
-		logrus.Errorf("mount watcher: fd %d out of int32 range", fd)
+		errChan <- fmt.Errorf("fd %d out of int32 range", fd)
 		return
 	}
 	fdInt32 := int32(fd) //nolint:gosec // fd is guaranteed non-negative by Open and bounded by math.MaxInt32 check above
@@ -51,14 +53,14 @@ func (u *Udev) watchMounts(ctx context.Context) {
 		default:
 		}
 
-		logrus.Debugf("mount watcher: polling fd=%d for POLLERR, timeout=5s", fd)
-		n, err := unix.Poll(fds, 5*1000)
+		logrus.Debugf("mount watcher: polling fd=%d for POLLERR", fd)
+		n, err := unix.Poll(fds, -1)
 		if err != nil {
 			if err == unix.EINTR {
 				logrus.Debug("mount watcher: poll interrupted by signal, retrying")
 				continue
 			}
-			logrus.Errorf("mount watcher: poll error: %v", err)
+			errChan <- fmt.Errorf("poll error: %w", err)
 			return
 		}
 		if n == 0 {

--- a/pkg/udev/mount_watcher_stub.go
+++ b/pkg/udev/mount_watcher_stub.go
@@ -4,4 +4,4 @@ package udev
 
 import "context"
 
-func (u *Udev) watchMounts(_ context.Context) {}
+func (u *Udev) watchMounts(_ context.Context, _ chan error) {}

--- a/pkg/udev/mount_watcher_stub.go
+++ b/pkg/udev/mount_watcher_stub.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package udev
+
+import "context"
+
+func (u *Udev) watchMounts(_ context.Context) {}

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -41,7 +41,7 @@ func (u *Udev) Monitor(ctx context.Context) {
 	// because any error will break the monitor loop.
 	errChan := make(chan error)
 	go u.spawnMonitor(ctx, errChan)
-
+	go u.watchMounts(ctx)
 }
 
 func (u *Udev) spawnMonitor(ctx context.Context, errChan chan error) {

--- a/pkg/udev/uevent.go
+++ b/pkg/udev/uevent.go
@@ -9,13 +9,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pilebones/go-udev/netlink"
-	"github.com/sirupsen/logrus"
-
 	"github.com/harvester/node-disk-manager/pkg/block"
 	"github.com/harvester/node-disk-manager/pkg/controller/blockdevice"
 	"github.com/harvester/node-disk-manager/pkg/option"
 	"github.com/harvester/node-disk-manager/pkg/utils"
+	"github.com/pilebones/go-udev/netlink"
+	"github.com/sirupsen/logrus"
 )
 
 type Udev struct {
@@ -39,9 +38,10 @@ func NewUdev(opt *option.Option, scanner *blockdevice.Scanner) *Udev {
 func (u *Udev) Monitor(ctx context.Context) {
 	// we need to respawn the monitor with any error.
 	// because any error will break the monitor loop.
-	errChan := make(chan error)
-	go u.spawnMonitor(ctx, errChan)
-	go u.watchMounts(ctx)
+	udevErrChan := make(chan error)
+	go u.spawnMonitor(ctx, udevErrChan)
+	mountErrChan := make(chan error)
+	go u.spawnMountWatcher(ctx, mountErrChan)
 }
 
 func (u *Udev) spawnMonitor(ctx context.Context, errChan chan error) {
@@ -51,6 +51,19 @@ func (u *Udev) spawnMonitor(ctx context.Context, errChan chan error) {
 		case err := <-errChan:
 			logrus.Errorf("failed to monitor udev events, error: %s", err.Error())
 			go u.monitor(ctx, errChan)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (u *Udev) spawnMountWatcher(ctx context.Context, errChan chan error) {
+	go u.watchMounts(ctx, errChan)
+	for {
+		select {
+		case err := <-errChan:
+			logrus.Errorf("failed to watch mounts, error: %s", err.Error())
+			go u.watchMounts(ctx, errChan)
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
**Problem:**

When users manually mount a disk, the disk is still an available option in harvester host configuration.
Users might accidentally select the mounted disk as harvester backend storage.

**Solution:**

We should skip mounted disks.

**Related Issue:**

https://github.com/harvester/harvester/issues/8990

**Test plan:**

https://github.com/user-attachments/assets/3722e640-c899-4c05-ac95-6a6fc77c7971



