### PR TITLE
Change lhv2 default disk driver to aio

### DIFF
--- a/pkg/provisioner/longhornv2.go
+++ b/pkg/provisioner/longhornv2.go
@@ -31,12 +31,7 @@ func NewLHV2Provisioner(
 		return nil, errors.New(ErrorCacheDiskTagsNotInitialized)
 	}
 	if device.Spec.Provisioner.Longhorn.DiskDriver == longhornv1.DiskDriverNone {
-		// We need to force DiskDriver to "auto" if it's not explicitly set,
-		// because Longhorn also does that internally.  If we don't do it
-		// here, the subsequent reflect.DeepEqual() in our Update() function
-		// will always fail because we have an empty string, but the LHN CR
-		// has it set to "auto" which results in a weird resync loop.
-		device.Spec.Provisioner.Longhorn.DiskDriver = longhornv1.DiskDriverAuto
+		device.Spec.Provisioner.Longhorn.DiskDriver = longhornv1.DiskDriverAio
 	}
 	baseProvisioner := &provisioner{
 		name:      TypeLonghornV2,


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester/issues/11041

**Solution:**

Change lhv2 default disk driver to aio

**Related Issue:**
https://github.com/harvester/harvester/issues/11041

**Test plan:**
- setup a harvester cluster which includes this patch
- enable lhv2 and then add lhv2 disk to host
- go check nodes.longhorn.io and check the diskDriver
For example:
```
harvester-node-1:~ # kubectl -n longhorn-system get nodes.longhorn.io hp-114-tink-system -o yaml \
>   | yq -r '(["DISK", "PATH", "DISK_DRIVER"], (.spec.disks | to_entries[] | [.key, .value.path, (.value.diskDriver // "")])) | @tsv'
DISK	PATH	DISK_DRIVER
41ea4751-0454-4db4-bf98-b24bb046a78d	/dev/disk/by-id/nvme-eui.0025385a2140c504	aio
default-disk-fe74993ab4cb6b6b	/var/lib/harvester/defaultdisk
```
41ea4751-0454-4db4-bf98-b24bb046a78d is the lhv2 disk, and its DISK_DRIVER is `aio`
