### PR TITLE
ci: fix node 20 issue temporarily

### DIFF
--- a/.github/workflows/factory.yaml
+++ b/.github/workflows/factory.yaml
@@ -15,6 +15,7 @@ env:
   repo: "rancher"
   controllerImageName: "harvester-node-disk-manager"
   webhookImageName: "harvester-node-disk-manager-webhook"
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   dapper-build:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   fossa-scanning:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Problem:**

Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**Solution:**

Although upstream opened an issue to track, we're not sure when they will finish. We can set the env temporarily to make CI pass.

Also, we'll need to open an issue

**Related Issue:**
https://github.com/rancher-eio/read-vault-secrets/issues/3


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

